### PR TITLE
Added ability for the client to request that the EDNS DO bit be set.

### DIFF
--- a/src/DnsClient/DnsMessageHandler.cs
+++ b/src/DnsClient/DnsMessageHandler.cs
@@ -63,6 +63,7 @@ namespace DnsClient
             * */
 
             var opt = new OptRecord();
+            opt.IsDnsSecOk = request.Header.RequestDnsSecRecords;
 
             writer.WriteHostName("");
             writer.WriteUInt16NetworkOrder((ushort)opt.RecordType);

--- a/src/DnsClient/DnsRequestHeader.cs
+++ b/src/DnsClient/DnsRequestHeader.cs
@@ -68,16 +68,24 @@ namespace DnsClient
             }
         }
 
+        public bool RequestDnsSecRecords { get; set; }
+
         public DnsRequestHeader(int id, DnsOpCode queryKind)
-            : this(id, true, queryKind)
+            : this(id, true, queryKind, false)
         {
         }
 
         public DnsRequestHeader(int id, bool useRecursion, DnsOpCode queryKind)
+            : this(id, useRecursion, queryKind, false)
+        {
+        }
+
+        public DnsRequestHeader(int id, bool useRecursion, DnsOpCode queryKind, bool requestDnsSecRecords)
         {
             Id = id;
             OpCode = queryKind;
-            UseRecursion = useRecursion;            
+            UseRecursion = useRecursion;
+            RequestDnsSecRecords = requestDnsSecRecords;
         }
 
         public override string ToString()

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -71,6 +71,8 @@ namespace DnsClient
         /// <inheritdoc />
         public bool ThrowDnsErrors { get; set; } = false;
 
+        public bool RequestDnsSecRecords { get; set; } = false;
+
         /// <inheritdoc />
         public TimeSpan Timeout
         {
@@ -273,7 +275,7 @@ namespace DnsClient
                 throw new ArgumentNullException(nameof(question));
             }
 
-            var head = new DnsRequestHeader(GetNextUniqueId(), Recursion, DnsOpCode.Query);
+            var head = new DnsRequestHeader(GetNextUniqueId(), Recursion, DnsOpCode.Query, RequestDnsSecRecords);
             var request = new DnsRequestMessage(head, question);
             var handler = UseTcpOnly ? _tcpFallbackHandler : _messageHandler;
 
@@ -445,7 +447,7 @@ namespace DnsClient
                 throw new ArgumentNullException(nameof(question));
             }
 
-            var head = new DnsRequestHeader(GetNextUniqueId(), Recursion, DnsOpCode.Query);
+            var head = new DnsRequestHeader(GetNextUniqueId(), Recursion, DnsOpCode.Query, RequestDnsSecRecords);
             var request = new DnsRequestMessage(head, question);
             var handler = UseTcpOnly ? _tcpFallbackHandler : _messageHandler;
 


### PR DESCRIPTION
This allows the client to receive DNSSEC records and also means that the AD bit will be set if the resolver validates the data.

Added field ILookupClient.RequestDnsSecRecords.
Changed DnsRequestHeader to contain this field.
Changed DnsMessageHandler to write this field out to the OPT record.