### PR TITLE
Add support for SSHFP

### DIFF
--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -143,6 +143,10 @@ namespace DnsClient
                     result = ResolveCaaRecord(info);
                     break;
 
+                case ResourceRecordType.SSHFP:
+                    result = ResolveSshfpRecord(info);
+                    break;
+
                 default:
                     // update reader index because we don't read full data for the empty record
                     _reader.Index += info.RawDataLength;
@@ -230,6 +234,15 @@ namespace DnsClient
             }
 
             return new TxtRecord(info, values.ToArray(), utf8Values.ToArray());
+        }
+
+        private DnsResourceRecord ResolveSshfpRecord(ResourceRecordInfo info)
+        {
+            var algorithm = (SshfpAlgorithm)_reader.ReadByte();
+            var fingerprintType = (SshfpFingerprintType)_reader.ReadByte();
+            var fingerprint = _reader.ReadBytes(info.RawDataLength - 2).ToArray();
+            var fingerprintHexString = string.Join(string.Empty, fingerprint.Select(b => b.ToString("X2")));
+            return new SshfpRecord(info, algorithm, fingerprintType, fingerprintHexString);
         }
 
         private DnsResourceRecord ResolveCaaRecord(ResourceRecordInfo info)

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -169,6 +169,12 @@ namespace DnsClient.Protocol
         OPT = 41,
 
         /// <summary>
+        /// SSH finger print record
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc4255">RFC 4255</seealso>
+        SSHFP = 44,
+
+        /// <summary>
         /// RRSIG rfc3755.
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc3755">RFC 3755</seealso>

--- a/src/DnsClient/Protocol/SshfpRecord.cs
+++ b/src/DnsClient/Protocol/SshfpRecord.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DnsClient.Protocol
+{
+    /// <summary>
+    /// A <see cref="DnsResourceRecord"/> represending an SSH fingerprint
+    /// <para>
+    /// SSHFP RRs are used to hold SSH fingerprints. Upon connecting to a
+    /// host an SSH client may choose to query for this to check the fingerprint(s)
+    /// </para>
+    /// </summary>
+    /// <seealso href="https://tools.ietf.org/html/rfc4255">RFC 4255</seealso>
+    /// <seealso href="https://tools.ietf.org/html/rfc6594">RFC 6594</seealso>
+    /// <seealso href="https://tools.ietf.org/html/rfc7479">RFC 7479</seealso>
+    public class SshfpRecord : DnsResourceRecord
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="info">The information.</param>
+        /// <param name="algorithm">The algorithm.</param>
+        /// <param name="fingerprintType">The fingerprint type.</param>
+        /// <param name="fingerprint">The fingerprint.</param>
+        public SshfpRecord(ResourceRecordInfo info, SshfpAlgorithm algorithm, SshfpFingerprintType fingerprintType, string fingerprint) : base(info)
+        {
+            Algorithm = algorithm;
+            FingerprintType = fingerprintType;
+            Fingerprint = fingerprint;
+        }
+
+        /// <summary>
+        /// Algorithm used for the fingerprint
+        /// </summary>
+        public SshfpAlgorithm Algorithm { get; }
+
+        /// <summary>
+        /// Fingerprint type used for the fingerprint
+        /// </summary>
+        public SshfpFingerprintType FingerprintType { get; }
+
+        /// <summary>
+        /// Fingerprint as defined in the RR
+        /// </summary>
+        public string Fingerprint { get; }
+
+        private protected override string RecordToString()
+        {
+            return $"{(int)Algorithm} {(int)FingerprintType} {Fingerprint}";
+        }
+    }
+
+    /// <summary>
+    /// Algorithm used by <see cref="SshfpRecord"/>
+    /// </summary>
+    public enum SshfpAlgorithm
+    {
+        /// <summary>
+        /// Reserved for later use
+        /// </summary>
+        Reserved = 0,
+
+        /// <summary>
+        /// RSA
+        /// </summary>
+        RSA = 1,
+
+        /// <summary>
+        /// DSS
+        /// </summary>
+        DSS = 2,
+
+        /// <summary>
+        /// Eliptic Curve DSA
+        /// </summary>
+        ECDSA = 3,
+
+        /// <summary>
+        /// Edwards-curve DSA
+        /// </summary>
+        Ed25519 = 4,
+    }
+
+    /// <summary>
+    /// Fingerprint type used by <see cref="SshfpRecord"/>
+    /// </summary>
+    public enum SshfpFingerprintType
+    {
+        /// <summary>
+        /// Reserved for later use
+        /// </summary>
+        Reserved = 0,
+
+        /// <summary>
+        /// SHA-1 fingerprint
+        /// </summary>
+        SHA1 = 1,
+
+        /// <summary>
+        /// SHA-256 fingerprint
+        /// </summary>
+        SHA256 = 2,
+    }
+}

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -191,5 +191,12 @@ namespace DnsClient
         /// <seealso href="https://tools.ietf.org/html/rfc6844">RFC 6844</seealso>
         /// <seealso cref="CaaRecord"/>
         CAA = ResourceRecordType.CAA,
+
+        /// <summary>
+        /// A SSH Fingerprint resource record.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc4255">RFC 4255</seealso>
+        /// <seealso cref="SshfpRecord"/>
+        SSHFP = ResourceRecordType.SSHFP,
     }
 }

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -324,6 +324,31 @@ namespace DnsClient.Tests
         }
 
         [Fact]
+        public void DnsRecordFactory_SSHFPRecord()
+        {
+            var algo = SshfpAlgorithm.RSA;
+            var type = SshfpFingerprintType.SHA1;
+            var fingerprint = "9DBA55CEA3B8E15528665A6781CA7C35190CF0EC";
+            // Value is stored as raw bytes in the record, so convert the HEX string above to it's original bytes
+            var fingerprintBytes = Enumerable.Range(0, fingerprint.Length / 2)
+                .Select(i => Convert.ToByte(fingerprint.Substring(i * 2, 2), 16));
+
+            var data = new List<byte>();
+            data.Add((byte)algo);
+            data.Add((byte)type);
+            data.AddRange(fingerprintBytes);
+
+            var factory = GetFactory(data.ToArray());
+            var info = new ResourceRecordInfo("query.example.com", ResourceRecordType.SSHFP, QueryClass.IN, 0, data.Count);
+
+            var result = factory.GetRecord(info) as SshfpRecord;
+
+            Assert.Equal(SshfpAlgorithm.RSA, result.Algorithm);
+            Assert.Equal(SshfpFingerprintType.SHA1, result.FingerprintType);
+            Assert.Equal(fingerprint, result.Fingerprint);
+        }
+
+        [Fact]
         public void DnsRecordFactory_SpecialChars()
         {
             var textA = "\"äöü \\slash/! @bla.com \"";


### PR DESCRIPTION
At the moment SSHFP is not supported, this pull requests adds support. This code is based on [RFC 4255](https://tools.ietf.org/html/rfc4255) which defines the basic implementation, [RFC 6594](https://tools.ietf.org/html/rfc6594) which adds ECDSA and SHA-256 support, and finally [RFC 7479](https://tools.ietf.org/html/rfc7479) which adds Ed25519 support.

If any changes need to be done, please let me know.