### PR TITLE
Fix receiving 'OPT' record.

### DIFF
--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -173,6 +173,7 @@ namespace DnsClient
 
         private DnsResourceRecord ResolveOptRecord(ResourceRecordInfo info)
         {
+            _reader.Index = _reader.Index + info.RawDataLength;
             return new OptRecord((int)info.RecordClass, info.InitialTimeToLive, info.RawDataLength);
         }
 


### PR DESCRIPTION
Fixed a "Record reader index out of sync." error that occurred when the _reader.Index was not changed when 'OPT' record was received.

'Cloudflare DNS over HTTPS' returns 'OPT' record. (using wire format.)
