### PR TITLE
Fixing memory leak when using nameserver discovery and NetworkAddressChanged events

### DIFF
--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
 
     <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net45;net471</TargetFrameworks>

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -377,15 +377,6 @@ namespace DnsClient
             {
                 _resolvedNameServers = NameServer.ResolveNameServers(skipIPv6SiteLocal: true, fallbackToGooglePublicDns: false);
                 servers = servers.Concat(_resolvedNameServers).ToArray();
-
-                try
-                {
-                    NetworkChange.NetworkAddressChanged += CheckResolvedNameserversCallback;
-                }
-                catch
-                {
-                    // Just in case
-                }
                 
                 // This will periodically get triggered on Query calls and
                 // will perform the same check as on NetworkAddressChanged.
@@ -406,16 +397,6 @@ namespace DnsClient
 
             Settings = new LookupClientSettings(options, servers);
             Cache = new ResponseCache(true, Settings.MinimumCacheTimeout, Settings.MaximumCacheTimeout);
-        }
-
-        private void CheckResolvedNameserversCallback(object sender, EventArgs args)
-        {
-            if (_logger.IsEnabled(LogLevel.Information))
-            {
-                _logger.LogInformation("Network change detected, trying to resolve name servers...");
-            }
-
-            CheckResolvedNameservers();
         }
 
         private void CheckResolvedNameservers()


### PR DESCRIPTION
Removing the feature added in 1.3.0 to listen to network change events.
Fixes #67 