### PR TITLE
Add TLSA and RRSIG support

### DIFF
--- a/src/DnsClient/DateTimeExtensions.cs
+++ b/src/DnsClient/DateTimeExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Text;
+
+namespace DnsClient
+{
+    /// <summary>
+    /// Extension method for <see cref="DateTime"/>
+    /// </summary>
+    public static class MyDateTimeExtension
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dateTime"></param>
+        /// <returns></returns>
+        public static string ToRrsigDateString(this DateTime dateTime)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append(dateTime.Year);
+            stringBuilder.Append(dateTime.Month);
+            stringBuilder.Append(dateTime.Day);
+            stringBuilder.Append(dateTime.Hour);
+            stringBuilder.Append(dateTime.Minute);
+            stringBuilder.Append(dateTime.Second);
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/src/DnsClient/DnsDatagramReader.cs
+++ b/src/DnsClient/DnsDatagramReader.cs
@@ -353,20 +353,6 @@ namespace DnsClient
 
             return (uint)(ReadUInt16NetworkOrder() << 16 | ReadUInt16NetworkOrder());
         }
-
-        public string ReadSignersNameFieldOfRrsig()
-        {
-            var bytesToInclude = new List<byte>();
-
-            byte value;
-
-            while ((value = ReadByte()) != 0)
-            {
-                bytesToInclude.Add(value);
-            };
-
-            return Encoding.ASCII.GetString(bytesToInclude.ToArray());
-        }
     }
 
     internal static class ArraySegmentExtensions

--- a/src/DnsClient/DnsDatagramReader.cs
+++ b/src/DnsClient/DnsDatagramReader.cs
@@ -131,6 +131,14 @@ namespace DnsClient
             return result;
         }
 
+        public ArraySegment<byte> ReadBytesToEnd(int startIndex, int lengthOfRawData)
+        {
+            var bytesRead = _index - startIndex;
+            var length = lengthOfRawData - bytesRead;
+
+            return ReadBytes(length);
+        }
+
         public IPAddress ReadIPAddress()
         {
             if (_count < _index + IPv4Length)
@@ -344,6 +352,20 @@ namespace DnsClient
             }
 
             return (uint)(ReadUInt16NetworkOrder() << 16 | ReadUInt16NetworkOrder());
+        }
+
+        public string ReadSignersNameFieldOfRrsig()
+        {
+            var bytesToInclude = new List<byte>();
+
+            byte value;
+
+            while ((value = ReadByte()) != 0)
+            {
+                bytesToInclude.Add(value);
+            };
+
+            return Encoding.ASCII.GetString(bytesToInclude.ToArray());
         }
     }
 

--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -184,9 +184,9 @@ namespace DnsClient
         private DnsResourceRecord ResolveTlsaRecord(ResourceRecordInfo info)
         {
             var startIndex = _reader.Index;
-            var certificateUsage = _reader.ReadByte();
-            var selector = _reader.ReadByte();
-            var matchingType = _reader.ReadByte();
+            var certificateUsage = (ECertificateUsage)_reader.ReadByte();
+            var selector = (ESelector)_reader.ReadByte();
+            var matchingType = (EMatchingType)_reader.ReadByte();
             var certificateAssociationData = Convert.ToBase64String(_reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray());
             return new TLSARecord(info, certificateUsage, selector, matchingType, certificateAssociationData);
         }

--- a/src/DnsClient/Protocol/RRSIGRecord.cs
+++ b/src/DnsClient/Protocol/RRSIGRecord.cs
@@ -1,0 +1,160 @@
+﻿using System;
+
+namespace DnsClient.Protocol
+{
+    /* https://tools.ietf.org/html/rfc4034#section3.1
+      3.1 RRSIG RDATA Wire Format
+
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |        Type Covered           |  Algorithm    |     Labels    |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |                         Original TTL                          |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |                      Signature Expiration                     |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |                      Signature Inception                      |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |            Key Tag            |                               /
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+         Signer's Name         /
+           /                                                               /
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           /                                                               /
+           /                            Signature                          /
+           /                                                               /
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+        TYPE COVERED: 2 octet field that identifies the type of the RRset that is
+        covered by this RRSIG record, in network byte order
+
+        ALGORITHM NUMBER FIELD: 1 octet field that identifies the cryptographic algorithm
+        used to create the signature
+
+        LABELS: 1 octet field that specifies the number of labels in the original RRSIG
+        RR owner name
+
+        ORIGINAL TTL: 4 octet field that specifies the TTL of the covered RRset as it
+        appears in the authoritative zone, in network byte order
+
+        SIGNATURE EXPIRATION: 4 octet field that specifies the expiration date of the 
+        signature in the form of a 32-bit unsigned number of seconds elapsed
+        since 1 January 1970 00:00:00 UTC, ignoring leap seconds, in network
+        byte order
+
+        SIGNATURE INCEPTION: 4 octet field that specifies the inception date of the 
+        signature in the form of a 32-bit unsigned number of seconds elapsed
+        since 1 January 1970 00:00:00 UTC, ignoring leap seconds, in network
+        byte order
+
+        KEY TAG: 2 octet field that contains the key tag value of the DNSKEY RR that 
+        validates this signature, in network byte order
+
+        SIGNER'S NAME FIELD: identifies the owner name of the DNSKEY
+        RR that a validator is supposed to use to validate this signature. SIZE UNKNOWN
+
+        SIGNATURE FIELD: ontains the cryptographic signature that covers
+        the RRSIG RDATA (excluding the Signature field) and the RRset
+        specified by the RRSIG owner name, RRSIG class, and RRSIG Type
+        Covered field.  The format of this field depends on the algorithm in
+        use SIZE UNKNOWN
+    */
+
+    /// <summary>
+    /// a <see cref="DnsResourceRecord"/> representing a TLSA record
+    /// </summary>
+    /// <seealso href="https://tools.ietf.org/html/rfc4033"/>
+    /// <seealso href="https://tools.ietf.org/html/rfc4034"/>
+    /// <seealso href="https://tools.ietf.org/html/rfc4035"/>
+    [CLSCompliant(false)]
+    public class RRSIGRecord : DnsResourceRecord
+    {
+
+        /// <summary>
+        /// Gets the type of the RRset that is covered by this RRSIG record.
+        /// </summary>
+        public ushort Type { get; }
+
+        /// <summary>
+        /// Gets cryptographic algorithm used to create the signature
+        /// </summary>
+        public byte AlgorithmNumber { get; }
+
+        /// <summary>
+        /// Gets number of labels in the original RRSIG RR owner name
+        /// </summary>
+        public byte Labels { get; }
+
+        /// <summary>
+        /// Gets TTL of the covered RRset as it appears in the authoritative zone
+        /// </summary>
+        public uint OriginalTtl { get; }
+
+        /// <summary>
+        /// Gets the expiration date of the signature
+        /// </summary>
+        public string SignatureExpiration { get; }
+
+        /// <summary>
+        /// Gets the inception date of the signature
+        /// </summary>
+        public string SignatureInception { get; }
+
+        /// <summary>
+        /// Gets the key tag value of the DNSKEY RR that validates this signature
+        /// </summary>
+        public ushort KeyTag { get; }
+
+        /// <summary>
+        /// Gets the owner name of the DNSKEY RR
+        /// </summary>
+        public DnsString SignersNameField { get; }
+
+        /// <summary>
+        /// Gets the cryptographic signature that covers the RRSIG RDATA(excluding the Signature field) and the RRset
+        /// </summary>
+        public string SignatureField { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RRSIGRecord"/> class
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="type"></param>
+        /// <param name="algorithmNumber"></param>
+        /// <param name="labels"></param>
+        /// <param name="originalTtl"></param>
+        /// <param name="signatureExpiration">Stored as YYYYMMDDHHmmSS</param>
+        /// <param name="signatureInception">Stored as YYYYMMDDHHmmSS</param>
+        /// <param name="keyTag"></param>
+        /// <param name="signersNameField"></param>
+        /// <param name="signatureField">Base64 encoded</param>
+        public RRSIGRecord(ResourceRecordInfo info, ushort type, byte algorithmNumber, byte labels, uint originalTtl,
+            uint signatureExpiration, uint signatureInception, ushort keyTag, DnsString signersNameField, string signatureField)
+            : base(info)
+        {
+            Type = type;
+            AlgorithmNumber = algorithmNumber;
+            Labels = labels;
+            OriginalTtl = originalTtl;
+            SignatureExpiration = SignatureDateToDigFormat(signatureExpiration);
+            SignatureInception = SignatureDateToDigFormat(signatureInception);
+            KeyTag = keyTag;
+            SignersNameField = signersNameField;
+            SignatureField = signatureField;
+        }
+
+        /// <summary>
+        /// Returns same values as dig
+        /// </summary>
+        /// <returns></returns>
+        private protected override string RecordToString()
+        {
+
+            return string.Format("{0} {1} {2} {3} {4} {5} {6} {7} {8}", (ResourceRecordType)Type, AlgorithmNumber, Labels,
+                OriginalTtl, SignatureExpiration, SignatureInception, KeyTag, SignersNameField, SignatureField);
+        }
+
+        private string SignatureDateToDigFormat(uint signatureDate)
+        {
+            return new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(signatureDate).ToRrsigDateString();
+        }
+    }
+}

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -181,6 +181,12 @@ namespace DnsClient.Protocol
         RRSIG = 46,
 
         /// <summary>
+        /// TLSA rfc6698
+        /// </summary>
+        /// <seealso href="https://https://tools.ietf.org/html/rfc6698">RFC 6698</seealso>
+        TLSA = 52,
+
+        /// <summary>
         /// A Uniform Resource Identifier (URI) resource record.
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc7553">RFC 7553</seealso>

--- a/src/DnsClient/Protocol/TLSARecord.cs
+++ b/src/DnsClient/Protocol/TLSARecord.cs
@@ -1,0 +1,94 @@
+﻿using System;
+
+namespace DnsClient.Protocol
+{
+    /* https://tools.ietf.org/html/rfc6698#Section2.1
+      2.1 TLSA Data format
+
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |  Cert. Usage  |   Selector    | Matching Type |               /
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+               /
+           /                                                               /
+           /                 Certificate Association Data                  /
+           /                                                               /
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+        where:
+
+        CERTIFICATEU SAGE: octet that specifies how to verify the certificate
+
+        SELECTOR: octet that specifies which part of the certificate should be checked
+
+        MATCHING TYPE: octet that specifies how the certificate association is presented
+
+        CERTIFICATE ASSOCIATION DATA: string of hexadecimal characters that specifies the 
+        actual data to be matched given the settings of the other fields
+
+    */
+
+    /// <summary>
+    /// a <see cref="DnsResourceRecord"/> representing a TLSA record
+    /// </summary>
+    /// <seealso href="https://tools.ietf.org/html/rfc6698"/>
+    /// <seealso href="https://en.wikipedia.org/wiki/DNS-based_Authentication_of_Named_Entities#TLSA_RR"/>
+    [CLSCompliant(false)]
+    public class TLSARecord : DnsResourceRecord
+    {
+
+        /// <summary>
+        /// Gets octet that specifies how to verify the certificate
+        /// Value of 0: RR points to a trust anchor and PKIX validation is required
+        /// Value of 1: RR points to an end entity certificate, PKIX validation is required
+        /// Value of 2: RR points to a trust anchor, but PKIX validation is NOT required
+        /// Value of 3: RR points to an end entity certificate, but PKIX validation is NOT required
+        /// </summary>
+        public byte CertificateUsage { get; }
+
+        /// <summary>
+        /// Gets octet that specifies which part of the certificate should be checked
+        /// Value of 0: Select the entire certificate for matching
+        /// Value of 1: Select the public key for certificate matching
+        /// </summary>
+        public byte Selector { get; }
+
+        /// <summary>
+        /// Gets octet that specifies how the certificate association is presented
+        /// Value of 0: Exact match on selected content
+        /// Value of 1: SHA-256 hash of selected content
+        /// Value of 2: SHA-512 hash of selected content 
+        /// </summary>
+        public byte MatchingType { get; }
+
+        /// <summary>
+        /// Gets string that specifies the actual data to be matched given the settings of the other fields
+        /// </summary>
+        public string CertificateAssociationData { get; }
+        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TLSARecord"/> class
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="certificateUsage"></param>
+        /// <param name="selector"></param>
+        /// <param name="matchingType"></param>
+        /// <param name="certificateAssociationData"></param>
+        public TLSARecord(ResourceRecordInfo info, byte certificateUsage, byte selector, byte matchingType, string certificateAssociationData)
+            : base(info)
+        {
+            CertificateUsage = certificateUsage;
+            Selector = selector;
+            MatchingType = matchingType;
+            CertificateAssociationData = certificateAssociationData;
+        }
+
+        /// <summary>
+        /// Returns same values as dig
+        /// </summary>
+        /// <returns></returns>
+        private protected override string RecordToString()
+        {
+            return string.Format("{0} {1} {2} {3}", CertificateUsage, Selector, MatchingType, CertificateAssociationData);
+        }
+    }
+}

--- a/src/DnsClient/Protocol/TLSARecord.cs
+++ b/src/DnsClient/Protocol/TLSARecord.cs
@@ -29,35 +29,26 @@ namespace DnsClient.Protocol
     /// <summary>
     /// a <see cref="DnsResourceRecord"/> representing a TLSA record
     /// </summary>
-    /// <seealso href="https://tools.ietf.org/html/rfc6698"/>
+    /// <seealso href="https://tools.ietf.org/html/rfc7671"/>
     /// <seealso href="https://en.wikipedia.org/wiki/DNS-based_Authentication_of_Named_Entities#TLSA_RR"/>
     [CLSCompliant(false)]
     public class TLSARecord : DnsResourceRecord
     {
 
         /// <summary>
-        /// Gets octet that specifies how to verify the certificate
-        /// Value of 0: RR points to a trust anchor and PKIX validation is required
-        /// Value of 1: RR points to an end entity certificate, PKIX validation is required
-        /// Value of 2: RR points to a trust anchor, but PKIX validation is NOT required
-        /// Value of 3: RR points to an end entity certificate, but PKIX validation is NOT required
+        /// Gets the <see cref="ECertificateUsage"/>
         /// </summary>
-        public byte CertificateUsage { get; }
+        public ECertificateUsage CertificateUsage { get; }
 
         /// <summary>
-        /// Gets octet that specifies which part of the certificate should be checked
-        /// Value of 0: Select the entire certificate for matching
-        /// Value of 1: Select the public key for certificate matching
+        /// Gets the <see cref="ECertificateUsage"/>
         /// </summary>
-        public byte Selector { get; }
+        public ESelector Selector { get; }
 
         /// <summary>
-        /// Gets octet that specifies how the certificate association is presented
-        /// Value of 0: Exact match on selected content
-        /// Value of 1: SHA-256 hash of selected content
-        /// Value of 2: SHA-512 hash of selected content 
+        /// Gets the <see cref="EMatchingType"/>
         /// </summary>
-        public byte MatchingType { get; }
+        public EMatchingType MatchingType { get; }
 
         /// <summary>
         /// Gets string that specifies the actual data to be matched given the settings of the other fields
@@ -73,7 +64,7 @@ namespace DnsClient.Protocol
         /// <param name="selector"></param>
         /// <param name="matchingType"></param>
         /// <param name="certificateAssociationData"></param>
-        public TLSARecord(ResourceRecordInfo info, byte certificateUsage, byte selector, byte matchingType, string certificateAssociationData)
+        public TLSARecord(ResourceRecordInfo info, ECertificateUsage certificateUsage, ESelector selector, EMatchingType matchingType, string certificateAssociationData)
             : base(info)
         {
             CertificateUsage = certificateUsage;
@@ -90,5 +81,68 @@ namespace DnsClient.Protocol
         {
             return string.Format("{0} {1} {2} {3}", CertificateUsage, Selector, MatchingType, CertificateAssociationData);
         }
+    }
+
+    /// <summary>
+    /// Gets octet that specifies how to verify the certificate
+    /// </summary>
+    public enum ECertificateUsage : byte
+    {
+        /// <summary>
+        /// RR points to a trust anchor and PKIX validation is required (PKIX-TA)
+        /// </summary>
+        PKIXTA = 0,
+
+        /// <summary>
+        /// RR points to an end entity certificate, PKIX validation is required (PKIX-EE)
+        /// </summary>
+        PKIXEE = 1,
+
+        /// <summary>
+        /// RR points to a trust anchor, but PKIX validation is NOT required (DANE-TA)
+        /// </summary>
+        DANETA = 2,
+
+        /// <summary>
+        /// RR points to an end entity certificate, but PKIX validation is NOT required (DANE-EE)
+        /// </summary>
+        DANEEE = 3
+    }
+
+    /// <summary>
+    /// Gets octet that specifies which part of the certificate should be checked
+    /// </summary>
+    public enum ESelector : byte
+    {
+        /// <summary>
+        /// Select the entire certificate for matching
+        /// </summary>
+        FullCertificate = 0,
+
+        /// <summary>
+        /// Select the public key for certificate matching
+        /// </summary>
+        PublicKey = 1
+    }
+
+    /// <summary>
+    /// Gets octet that specifies how the certificate association is presented
+    /// </summary>
+    public enum EMatchingType : byte
+    {
+        /// <summary>
+        /// Value of 0: Exact match on selected content
+        /// </summary>
+        ExactMatch = 0,
+
+        /// <summary>
+        /// Value of 1: SHA-256 hash of selected content
+        /// </summary>
+        SHA256 = 1,
+
+        /// <summary>
+        /// Value of 2: SHA-512 hash of selected content 
+        /// </summary>
+        SHA512 = 2,
     }
 }

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -165,6 +165,12 @@ namespace DnsClient
         RRSIG = ResourceRecordType.RRSIG,
 
         /// <summary>
+        /// TLSA rfc6698
+        /// </summary>
+        /// <seealso href="https://https://tools.ietf.org/html/rfc6698">RFC 6698</seealso>
+        TLSA = ResourceRecordType.TLSA,
+
+        /// <summary>
         /// DNS zone transfer request.
         /// This can be used only if <see cref="DnsQuerySettings.UseTcpOnly"/> is set to true as <c>AXFR</c> is only supported via TCP.
         /// <para>

--- a/src/DnsClient/ResourceRecordCollectionExtensions.cs
+++ b/src/DnsClient/ResourceRecordCollectionExtensions.cs
@@ -213,6 +213,26 @@ namespace System.Linq
         }
 
         /// <summary>
+        /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="TLSARecord"/>s only
+        /// </summary>
+        /// <param name="records"></param>
+        /// <returns>The list of <see cref="TLSARecord"/>.</returns>
+        public static IEnumerable<TLSARecord> TLSARecords (this IEnumerable<DnsResourceRecord> records)
+        {
+            return records.OfType<TLSARecord>();
+        }
+
+        /// <summary>
+        /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="RRSIGRecord"/>s only
+        /// </summary>
+        /// <param name="records"></param>
+        /// <returns>The list of <see cref="RRSIGRecord"/>.</returns>
+        public static IEnumerable<RRSIGRecord> RRSIGRecords(this IEnumerable<DnsResourceRecord> records)
+        {
+            return records.OfType<RRSIGRecord>();
+        }
+
+        /// <summary>
         /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="DnsResourceRecord"/>s
         /// which have the <paramref name="type"/>.
         /// </summary>

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -341,9 +341,9 @@ namespace DnsClient.Tests
 
             var result = factory.GetRecord(info) as TLSARecord;
 
-            Assert.Equal(certificateUsage, result.CertificateUsage);
-            Assert.Equal(selector, result.Selector);
-            Assert.Equal(matchingType, result.MatchingType);
+            Assert.Equal((ECertificateUsage)certificateUsage, result.CertificateUsage);
+            Assert.Equal((ESelector)selector, result.Selector);
+            Assert.Equal((EMatchingType)matchingType, result.MatchingType);
             // Checking this in both directions
             Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes(certificateAssociationData)), result.CertificateAssociationData);
             Assert.Equal(certificateAssociationData, Encoding.UTF8.GetString(Convert.FromBase64String(result.CertificateAssociationData)));

--- a/test/DnsClient.Tests/DnsResponseParsingTest.cs
+++ b/test/DnsClient.Tests/DnsResponseParsingTest.cs
@@ -37,7 +37,8 @@ namespace DnsClient.Tests
                 ResourceRecordType.MD,
                 ResourceRecordType.MF,
 #pragma warning restore CS0618 // Type or member is obsolete
-                ResourceRecordType.RRSIG
+                ResourceRecordType.RRSIG,
+                ResourceRecordType.TLSA
             };
 
             foreach (var t in types)


### PR DESCRIPTION
When I started workig on this issue, I wasn't aware of the other PR that was already created regarding support for TLSA.
I've also added RRSIG support though, so the data that can be displayed on a TLSA request is the same as when done with `dig`. 

I tried to adopt the code styll as much as possible but also added some new methods to make the code around the RRSIG better readable. Also added two unit tests, one for the RRSIG and one for the TLSA `GetRecord` methods

Please let me know what you think of this.

Best,

Mark