### PR TITLE
Adds cache queries and setting to opt in to caching failure responses

### DIFF
--- a/src/DnsClient/DnsQueryExtensions.cs
+++ b/src/DnsClient/DnsQueryExtensions.cs
@@ -618,14 +618,14 @@ namespace DnsClient
             return ResolveServiceProcessResult(result);
         }
 
-        private static string ConcatResolveServiceName(string baseDomain, string serviceName, string tag)
+        public static string ConcatResolveServiceName(string baseDomain, string serviceName, string tag)
         {
             return string.IsNullOrWhiteSpace(tag) ?
                 $"{serviceName}.{baseDomain}." :
                 $"_{serviceName}._{tag}.{baseDomain}.";
         }
 
-        private static ServiceHostEntry[] ResolveServiceProcessResult(IDnsQueryResponse result)
+        public static ServiceHostEntry[] ResolveServiceProcessResult(IDnsQueryResponse result)
         {
             var hosts = new List<ServiceHostEntry>();
             if (result == null || result.HasError)

--- a/src/DnsClient/DnsQueryExtensions.cs
+++ b/src/DnsClient/DnsQueryExtensions.cs
@@ -571,7 +571,7 @@ namespace DnsClient
                 throw new ArgumentNullException(nameof(serviceName));
             }
 
-            var queryString = ConcatResolveServiceName(baseDomain, serviceName, tag);
+            var queryString = ConcatServiceName(baseDomain, serviceName, tag);
 
             var result = query.Query(queryString, QueryType.SRV);
 
@@ -611,20 +611,32 @@ namespace DnsClient
                 throw new ArgumentNullException(nameof(serviceName));
             }
 
-            var queryString = ConcatResolveServiceName(baseDomain, serviceName, tag);
+            var queryString = ConcatServiceName(baseDomain, serviceName, tag);
 
             var result = await query.QueryAsync(queryString, QueryType.SRV).ConfigureAwait(false);
 
             return ResolveServiceProcessResult(result);
         }
 
-        public static string ConcatResolveServiceName(string baseDomain, string serviceName, string tag)
+        /// <summary>
+        /// Constructs a DNS <see cref="QueryType.SRV"/> query string from the constituent parts.
+        /// </summary>
+        /// <param name="baseDomain">The base domain, which will be appended to the end of the query string.</param>
+        /// <param name="serviceName">The name of the service to look for. Must not have any <c>_</c> prefix.</param>
+        /// <param name="tag">An optional tag. Must not have any <c>_</c> prefix.</param>
+        /// <returns>A service string that can be used in a DNS service query.</returns>
+        public static string ConcatServiceName(string baseDomain, string serviceName, string tag = null)
         {
             return string.IsNullOrWhiteSpace(tag) ?
                 $"{serviceName}.{baseDomain}." :
                 $"_{serviceName}._{tag}.{baseDomain}.";
         }
 
+        /// <summary>
+        /// Transforms a DNS query result into a collection of <see cref="ServiceHostEntry"/> objects.
+        /// </summary>
+        /// <param name="result">The DNS </param>
+        /// <returns>A collection of <see cref="ServiceHostEntry"/>s.</returns>
         public static ServiceHostEntry[] ResolveServiceProcessResult(IDnsQueryResponse result)
         {
             var hosts = new List<ServiceHostEntry>();

--- a/src/DnsClient/DnsQueryOptions.cs
+++ b/src/DnsClient/DnsQueryOptions.cs
@@ -27,7 +27,7 @@ namespace DnsClient
         private static readonly TimeSpan s_maxTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
         private TimeSpan _timeout = s_defaultTimeout;
         private int _ednsBufferSize = MaximumBufferSize;
-        private TimeSpan _cacheFailureDuration = s_defaultTimeout;
+        private TimeSpan _failedResultsCacheDuration = s_defaultTimeout;
 
         /// <summary>
         /// Gets or sets a flag indicating whether each <see cref="IDnsQueryResponse"/> will contain a full documentation of the response(s).
@@ -227,15 +227,15 @@ namespace DnsClient
         /// failures is to reduce repeated lookup attempts within a short space of time.
         /// Defaults to <c>False</c>.
         /// </summary>
-        public bool UseCacheForFailures { get; set; } = false;
+        public bool CacheFailedResults { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the duration to cache failed lookups. Does not apply if failed lookups are not being cached.
         /// Defaults to <c>5 seconds</c>.
         /// </summary>
-        public TimeSpan CacheFailureDuration
+        public TimeSpan FailedResultsCacheDuration
         {
-            get { return _cacheFailureDuration; }
+            get { return _failedResultsCacheDuration; }
             set
             {
                 if ((value <= TimeSpan.Zero || value > s_maxTimeout) && value != s_infiniteTimeout)
@@ -243,7 +243,7 @@ namespace DnsClient
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
-                _cacheFailureDuration = value;
+                _failedResultsCacheDuration = value;
             }
         }
 
@@ -645,13 +645,13 @@ namespace DnsClient
         /// failures is to reduce repeated lookup attempts within a short space of time.
         /// Defaults to <c>False</c>.
         /// </summary>
-        public bool UseCacheForFailures { get; }
+        public bool CacheFailedResults { get; }
 
         /// <summary>
         /// If failures are being cached this value indicates how long they will be held in the cache for.
         /// Defaults to <c>5 seconds</c>.
         /// </summary>
-        public TimeSpan CacheFailureDuration { get; }
+        public TimeSpan FailedResultsCacheDuration { get; }
 
         /// <summary>
         /// Creates a new instance of <see cref="DnsQueryAndServerSettings"/>.
@@ -676,8 +676,8 @@ namespace DnsClient
             UseTcpOnly = options.UseTcpOnly;
             ExtendedDnsBufferSize = options.ExtendedDnsBufferSize;
             RequestDnsSecRecords = options.RequestDnsSecRecords;
-            UseCacheForFailures = options.UseCacheForFailures;
-            CacheFailureDuration = options.CacheFailureDuration;
+            CacheFailedResults = options.CacheFailedResults;
+            FailedResultsCacheDuration = options.FailedResultsCacheDuration;
         }
 
         /// <inheritdocs />
@@ -722,8 +722,8 @@ namespace DnsClient
                    UseTcpOnly == other.UseTcpOnly &&
                    ExtendedDnsBufferSize == other.ExtendedDnsBufferSize &&
                    RequestDnsSecRecords == other.RequestDnsSecRecords &&
-                   UseCacheForFailures == other.UseCacheForFailures &&
-                   CacheFailureDuration.Equals(other.CacheFailureDuration);
+                   CacheFailedResults == other.CacheFailedResults &&
+                   FailedResultsCacheDuration.Equals(other.FailedResultsCacheDuration);
         }
     }
 

--- a/src/DnsClient/DnsQueryOptions.cs
+++ b/src/DnsClient/DnsQueryOptions.cs
@@ -27,6 +27,7 @@ namespace DnsClient
         private static readonly TimeSpan s_maxTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
         private TimeSpan _timeout = s_defaultTimeout;
         private int _ednsBufferSize = MaximumBufferSize;
+        private TimeSpan _cacheFailureDuration = s_defaultTimeout;
 
         /// <summary>
         /// Gets or sets a flag indicating whether each <see cref="IDnsQueryResponse"/> will contain a full documentation of the response(s).
@@ -232,7 +233,19 @@ namespace DnsClient
         /// Gets or sets the duration to cache failed lookups. Does not apply if failed lookups are not being cached.
         /// Defaults to <c>5 seconds</c>.
         /// </summary>
-        public TimeSpan CacheFailureDuration { get; set; } = s_defaultTimeout;
+        public TimeSpan CacheFailureDuration
+        {
+            get { return _cacheFailureDuration; }
+            set
+            {
+                if ((value <= TimeSpan.Zero || value > s_maxTimeout) && value != s_infiniteTimeout)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _cacheFailureDuration = value;
+            }
+        }
 
         /// <summary>
         /// Converts the query options into readonly settings.
@@ -710,7 +723,7 @@ namespace DnsClient
                    ExtendedDnsBufferSize == other.ExtendedDnsBufferSize &&
                    RequestDnsSecRecords == other.RequestDnsSecRecords &&
                    UseCacheForFailures == other.UseCacheForFailures &&
-                   CacheFailureDuration.Equals(other.Timeout);
+                   CacheFailureDuration.Equals(other.CacheFailureDuration);
         }
     }
 

--- a/src/DnsClient/DnsQueryOptions.cs
+++ b/src/DnsClient/DnsQueryOptions.cs
@@ -222,6 +222,19 @@ namespace DnsClient
         public bool RequestDnsSecRecords { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a flag indicating whether the DNS failures are being cached. The purpose of caching 
+        /// failures is to reduce repeated lookup attempts within a short space of time.
+        /// Defaults to <c>False</c>.
+        /// </summary>
+        public bool UseCacheForFailures { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the duration to cache failed lookups. Does not apply if failed lookups are not being cached.
+        /// Defaults to <c>5 seconds</c>.
+        /// </summary>
+        public TimeSpan CacheFailureDuration { get; set; } = s_defaultTimeout;
+
+        /// <summary>
         /// Converts the query options into readonly settings.
         /// </summary>
         /// <param name="fromOptions">The options.</param>
@@ -615,6 +628,19 @@ namespace DnsClient
         public bool RequestDnsSecRecords { get; }
 
         /// <summary>
+        /// Gets a flag indicating whether the DNS failures are being cached. The purpose of caching 
+        /// failures is to reduce repeated lookup attempts within a short space of time.
+        /// Defaults to <c>False</c>.
+        /// </summary>
+        public bool UseCacheForFailures { get; }
+
+        /// <summary>
+        /// If failures are being cached this value indicates how long they will be held in the cache for.
+        /// Defaults to <c>5 seconds</c>.
+        /// </summary>
+        public TimeSpan CacheFailureDuration { get; }
+
+        /// <summary>
         /// Creates a new instance of <see cref="DnsQueryAndServerSettings"/>.
         /// </summary>
         public DnsQuerySettings(DnsQueryOptions options)
@@ -637,6 +663,8 @@ namespace DnsClient
             UseTcpOnly = options.UseTcpOnly;
             ExtendedDnsBufferSize = options.ExtendedDnsBufferSize;
             RequestDnsSecRecords = options.RequestDnsSecRecords;
+            UseCacheForFailures = options.UseCacheForFailures;
+            CacheFailureDuration = options.CacheFailureDuration;
         }
 
         /// <inheritdocs />
@@ -680,7 +708,9 @@ namespace DnsClient
                    UseTcpFallback == other.UseTcpFallback &&
                    UseTcpOnly == other.UseTcpOnly &&
                    ExtendedDnsBufferSize == other.ExtendedDnsBufferSize &&
-                   RequestDnsSecRecords == other.RequestDnsSecRecords;
+                   RequestDnsSecRecords == other.RequestDnsSecRecords &&
+                   UseCacheForFailures == other.UseCacheForFailures &&
+                   CacheFailureDuration.Equals(other.Timeout);
         }
     }
 

--- a/src/DnsClient/IDnsQuery.cs
+++ b/src/DnsClient/IDnsQuery.cs
@@ -48,6 +48,29 @@ namespace DnsClient
         IDnsQueryResponse Query(DnsQuestion question, DnsQueryAndServerOptions queryOptions);
 
         /// <summary>
+        /// Performs a lookup for the given <paramref name="question" /> against the in-memory cache.
+        /// </summary>
+        /// <param name="question">The domain name query.</param>
+        /// <returns>
+        /// The <see cref="IDnsQueryResponse" /> which contains the cached response headers and lists of resource records.
+        /// If no matching cache entry is found null is returned.
+        /// </returns>
+        IDnsQueryResponse QueryCache(DnsQuestion question);
+
+        /// <summary>
+        /// Performs a DNS lookup for the given <paramref name="query" />, <paramref name="queryType" /> and <paramref name="queryClass" />
+        /// against the in-memory cache.
+        /// </summary>
+        /// <param name="query">The domain name query.</param>
+        /// <param name="queryType">The <see cref="QueryType" />.</param>
+        /// <param name="queryClass">The <see cref="QueryClass"/>.</param>
+        /// <returns>
+        /// The <see cref="IDnsQueryResponse" /> which contains the cached response headers and lists of resource records.
+        /// If no matching cache entry is found null is returned.
+        /// </returns>        
+        IDnsQueryResponse QueryCache(string query, QueryType queryType, QueryClass queryClass = QueryClass.IN);
+
+        /// <summary>
         /// Performs a DNS lookup for the given <paramref name="query" />, <paramref name="queryType" /> and <paramref name="queryClass" />
         /// </summary>
         /// <param name="query">The domain name query.</param>

--- a/src/DnsClient/IDnsQuery.cs
+++ b/src/DnsClient/IDnsQuery.cs
@@ -48,25 +48,31 @@ namespace DnsClient
         IDnsQueryResponse Query(DnsQuestion question, DnsQueryAndServerOptions queryOptions);
 
         /// <summary>
-        /// Performs a lookup for the given <paramref name="question" /> against the in-memory cache.
+        /// Returns cached results for the given <paramref name="question" /> from the in-memory cache, if available, or <c>Null</c> otherwise.
         /// </summary>
+        /// <remarks>
+        /// This method will not perform a full lookup if there is nothing found in cache or the cache is disabled!
+        /// </remarks>
         /// <param name="question">The domain name query.</param>
         /// <returns>
         /// The <see cref="IDnsQueryResponse" /> which contains the cached response headers and lists of resource records.
-        /// If no matching cache entry is found null is returned.
+        /// If no matching cache entry is found <c>Null</c> is returned.
         /// </returns>
         IDnsQueryResponse QueryCache(DnsQuestion question);
 
         /// <summary>
-        /// Performs a DNS lookup for the given <paramref name="query" />, <paramref name="queryType" /> and <paramref name="queryClass" />
-        /// against the in-memory cache.
+        /// Returns cached results for the given <paramref name="query" />, <paramref name="queryType" /> and <paramref name="queryClass" />
+        /// against the in-memory cache, if available, or <c>Null</c> otherwise.
         /// </summary>
+        /// <remarks>
+        /// This method will not perform a full lookup if there is nothing found in cache or the cache is disabled!
+        /// </remarks>
         /// <param name="query">The domain name query.</param>
         /// <param name="queryType">The <see cref="QueryType" />.</param>
         /// <param name="queryClass">The <see cref="QueryClass"/>.</param>
         /// <returns>
         /// The <see cref="IDnsQueryResponse" /> which contains the cached response headers and lists of resource records.
-        /// If no matching cache entry is found null is returned.
+        /// If no matching cache entry is found <c>Null</c> is returned.
         /// </returns>        
         IDnsQueryResponse QueryCache(string query, QueryType queryType, QueryClass queryClass = QueryClass.IN);
 

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -396,7 +396,7 @@ namespace DnsClient
             }
 
             Settings = new LookupClientSettings(options, servers);
-            Cache = new ResponseCache(true, Settings.MinimumCacheTimeout, Settings.MaximumCacheTimeout, Settings.CacheFailureDuration);
+            Cache = new ResponseCache(true, Settings.MinimumCacheTimeout, Settings.MaximumCacheTimeout, Settings.FailedResultsCacheDuration);
         }
 
         private void CheckResolvedNameservers()
@@ -894,7 +894,7 @@ namespace DnsClient
                         }
 
                         // If its the last server, return.
-                        if (settings.UseCache && settings.UseCacheForFailures)
+                        if (settings.UseCache && settings.CacheFailedResults)
                         {
                             Cache.Add(cacheKey, lastQueryResponse, true);
                         }
@@ -1150,7 +1150,7 @@ namespace DnsClient
                         }
 
                         // If its the last server, return.
-                        if (settings.UseCache && settings.UseCacheForFailures)
+                        if (settings.UseCache && settings.CacheFailedResults)
                         {
                             Cache.Add(cacheKey, lastQueryResponse, true);
                         }

--- a/test/DnsClient.Tests/LookupConfigurationTest.cs
+++ b/test/DnsClient.Tests/LookupConfigurationTest.cs
@@ -287,6 +287,8 @@ namespace DnsClient.Tests
             Assert.True(options.UseRandomNameServer);
             Assert.Equal(DnsQueryOptions.MaximumBufferSize, options.ExtendedDnsBufferSize);
             Assert.False(options.RequestDnsSecRecords);
+            Assert.False(options.UseCacheForFailures);
+            Assert.Equal(options.CacheFailureDuration, TimeSpan.FromSeconds(5));
         }
 
         [Fact]
@@ -311,6 +313,8 @@ namespace DnsClient.Tests
             Assert.True(options.UseRandomNameServer);
             Assert.Equal(DnsQueryOptions.MaximumBufferSize, options.ExtendedDnsBufferSize);
             Assert.False(options.RequestDnsSecRecords);
+            Assert.False(options.UseCacheForFailures);
+            Assert.Equal(options.CacheFailureDuration, TimeSpan.FromSeconds(5));
         }
 
         [Fact]
@@ -335,7 +339,9 @@ namespace DnsClient.Tests
                 UseTcpFallback = !defaultOptions.UseTcpFallback,
                 UseTcpOnly = !defaultOptions.UseTcpOnly,
                 ExtendedDnsBufferSize = 1234,
-                RequestDnsSecRecords = true
+                RequestDnsSecRecords = true,
+                UseCacheForFailures = true,
+                CacheFailureDuration = TimeSpan.FromSeconds(10)
             };
 
             var client = new LookupClient(options);
@@ -357,6 +363,8 @@ namespace DnsClient.Tests
             Assert.Equal(!defaultOptions.UseTcpOnly, client.Settings.UseTcpOnly);
             Assert.Equal(1234, client.Settings.ExtendedDnsBufferSize);
             Assert.Equal(!defaultOptions.RequestDnsSecRecords, client.Settings.RequestDnsSecRecords);
+            Assert.Equal(!defaultOptions.UseCacheForFailures, client.Settings.UseCacheForFailures);
+            Assert.Equal(TimeSpan.FromSeconds(10), client.Settings.CacheFailureDuration);
 
             Assert.Equal(new LookupClientSettings(options), client.Settings);
         }
@@ -560,6 +568,36 @@ namespace DnsClient.Tests
             var options = new LookupClientOptions();
 
             Action act = () => options.MaximumCacheTimeout = TimeSpan.FromDays(25);
+
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
+        }
+
+        [Fact]
+        public void LookupClientOptions_InvalidCacheFailureDuration()
+        {
+            var options = new LookupClientOptions();
+
+            Action act = () => options.CacheFailureDuration = TimeSpan.FromMilliseconds(0);
+
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
+        }
+
+        [Fact]
+        public void LookupClientOptions_InvalidCacheFailureDuration2()
+        {
+            var options = new LookupClientOptions();
+
+            Action act = () => options.CacheFailureDuration = TimeSpan.FromMilliseconds(-23);
+
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
+        }
+
+        [Fact]
+        public void LookupClientOptions_InvalidCacheFailureDuration3()
+        {
+            var options = new LookupClientOptions();
+
+            Action act = () => options.CacheFailureDuration = TimeSpan.FromDays(25);
 
             Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
         }

--- a/test/DnsClient.Tests/LookupConfigurationTest.cs
+++ b/test/DnsClient.Tests/LookupConfigurationTest.cs
@@ -287,8 +287,8 @@ namespace DnsClient.Tests
             Assert.True(options.UseRandomNameServer);
             Assert.Equal(DnsQueryOptions.MaximumBufferSize, options.ExtendedDnsBufferSize);
             Assert.False(options.RequestDnsSecRecords);
-            Assert.False(options.UseCacheForFailures);
-            Assert.Equal(options.CacheFailureDuration, TimeSpan.FromSeconds(5));
+            Assert.False(options.CacheFailedResults);
+            Assert.Equal(options.FailedResultsCacheDuration, TimeSpan.FromSeconds(5));
         }
 
         [Fact]
@@ -313,8 +313,8 @@ namespace DnsClient.Tests
             Assert.True(options.UseRandomNameServer);
             Assert.Equal(DnsQueryOptions.MaximumBufferSize, options.ExtendedDnsBufferSize);
             Assert.False(options.RequestDnsSecRecords);
-            Assert.False(options.UseCacheForFailures);
-            Assert.Equal(options.CacheFailureDuration, TimeSpan.FromSeconds(5));
+            Assert.False(options.CacheFailedResults);
+            Assert.Equal(options.FailedResultsCacheDuration, TimeSpan.FromSeconds(5));
         }
 
         [Fact]
@@ -340,8 +340,8 @@ namespace DnsClient.Tests
                 UseTcpOnly = !defaultOptions.UseTcpOnly,
                 ExtendedDnsBufferSize = 1234,
                 RequestDnsSecRecords = true,
-                UseCacheForFailures = true,
-                CacheFailureDuration = TimeSpan.FromSeconds(10)
+                CacheFailedResults = true,
+                FailedResultsCacheDuration = TimeSpan.FromSeconds(10)
             };
 
             var client = new LookupClient(options);
@@ -363,8 +363,8 @@ namespace DnsClient.Tests
             Assert.Equal(!defaultOptions.UseTcpOnly, client.Settings.UseTcpOnly);
             Assert.Equal(1234, client.Settings.ExtendedDnsBufferSize);
             Assert.Equal(!defaultOptions.RequestDnsSecRecords, client.Settings.RequestDnsSecRecords);
-            Assert.Equal(!defaultOptions.UseCacheForFailures, client.Settings.UseCacheForFailures);
-            Assert.Equal(TimeSpan.FromSeconds(10), client.Settings.CacheFailureDuration);
+            Assert.Equal(!defaultOptions.CacheFailedResults, client.Settings.CacheFailedResults);
+            Assert.Equal(TimeSpan.FromSeconds(10), client.Settings.FailedResultsCacheDuration);
 
             Assert.Equal(new LookupClientSettings(options), client.Settings);
         }
@@ -577,7 +577,7 @@ namespace DnsClient.Tests
         {
             var options = new LookupClientOptions();
 
-            Action act = () => options.CacheFailureDuration = TimeSpan.FromMilliseconds(0);
+            Action act = () => options.FailedResultsCacheDuration = TimeSpan.FromMilliseconds(0);
 
             Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
         }
@@ -587,7 +587,7 @@ namespace DnsClient.Tests
         {
             var options = new LookupClientOptions();
 
-            Action act = () => options.CacheFailureDuration = TimeSpan.FromMilliseconds(-23);
+            Action act = () => options.FailedResultsCacheDuration = TimeSpan.FromMilliseconds(-23);
 
             Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
         }
@@ -597,7 +597,7 @@ namespace DnsClient.Tests
         {
             var options = new LookupClientOptions();
 
-            Action act = () => options.CacheFailureDuration = TimeSpan.FromDays(25);
+            Action act = () => options.FailedResultsCacheDuration = TimeSpan.FromDays(25);
 
             Assert.ThrowsAny<ArgumentOutOfRangeException>(act);
         }


### PR DESCRIPTION
Adds a new public method to allow the cache to be queried. The point of this is to allow an application to take different actions depending on whether a network lookup needs to be undertaken or not. See #80.

Adds a setting to choose whether lookup failures should be cached and if so for how long. The point of this is to allow applications to avoid high frequency lookups on failing queries.