### PR TITLE
Validating ANY address usage

### DIFF
--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.3.2</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
 
     <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net45;net471</TargetFrameworks>

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -380,7 +380,7 @@ namespace DnsClient
 
                 // This will periodically get triggered on Query calls and
                 // will perform the same check as on NetworkAddressChanged.
-                // The event doesn't seem to get fired on Linux for example... 
+                // The event doesn't seem to get fired on Linux for example...
                 // TODO: Maybe there is a better way, but this will work for now.
                 _skipper = new SkipWorker(
                 () =>

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/DnsClient/NameServer.cs
+++ b/src/DnsClient/NameServer.cs
@@ -163,7 +163,7 @@ namespace DnsClient
         /// </returns>
         public override string ToString()
         {
-            return $"{Address}:{Port}";
+            return IPEndPoint.ToString();
         }
 
         /// <inheritdocs />
@@ -240,7 +240,7 @@ namespace DnsClient
                 }
                 else
                 {
-                    throw exceptions.First();
+                    throw new InvalidOperationException("Error resolving name servers", exceptions.First());
                 }
             }
 

--- a/test/DnsClient.Tests/LookupTest.cs
+++ b/test/DnsClient.Tests/LookupTest.cs
@@ -132,17 +132,6 @@ namespace DnsClient.Tests
             Assert.ThrowsAsync<ArgumentNullException>("queryOptions", () => client.QueryServerReverseAsync(servers, IPAddress.Loopback, null));
         }
 
-#if !NET461
-
-        [Fact]
-        public void NativeDnsServerResolution()
-        {
-            var ex = Record.Exception(() => NameServer.ResolveNameServersNative());
-            Assert.Null(ex);
-        }
-
-#endif
-
         [Fact]
         public async Task Lookup_GetHostAddresses_Local()
         {

--- a/test/DnsClient.Tests/LookupTest.cs
+++ b/test/DnsClient.Tests/LookupTest.cs
@@ -193,7 +193,7 @@ namespace DnsClient.Tests
         [Fact]
         public void Lookup_LargeResultWithTCP()
         {
-            var dns = new LookupClient(NameServer.GooglePublicDns);
+            var dns = new LookupClient(NameServer.Cloudflare);
 
             var result = dns.Query("big.basic.caatestsuite.com", QueryType.CAA);
 

--- a/test/DnsClient.Tests/NameServerTest.cs
+++ b/test/DnsClient.Tests/NameServerTest.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace DnsClient.Tests
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+
+    public class NameServerTest
+    {
+
+#if !NET461
+
+        [Fact]
+        public void NativeDnsServerResolution()
+        {
+            var ex = Record.Exception(() => NameServer.ResolveNameServersNative());
+            Assert.Null(ex);
+        }
+
+#endif
+    }
+}

--- a/test/DnsClient.Tests/NameServerTest.cs
+++ b/test/DnsClient.Tests/NameServerTest.cs
@@ -1,12 +1,13 @@
-﻿using Xunit;
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace DnsClient.Tests
 {
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-
     public class NameServerTest
     {
-
 #if !NET461
 
         [Fact]
@@ -17,5 +18,44 @@ namespace DnsClient.Tests
         }
 
 #endif
+
+        [Fact]
+        public void ValidateAnyAddressIPv4()
+        {
+            Assert.ThrowsAny<InvalidOperationException>(() => NameServer.ValidateNameServers(new[] { new NameServer(IPAddress.Any) }));
+        }
+
+        [Fact]
+        public void ValidateAnyAddressIPv6()
+        {
+            Assert.ThrowsAny<InvalidOperationException>(() => NameServer.ValidateNameServers(new[] { new NameServer(IPAddress.IPv6Any) }));
+        }
+
+        [Fact]
+        public void ValidateAnyAddress_LookupClientInit()
+        {
+            Assert.ThrowsAny<InvalidOperationException>(() => new LookupClient(IPAddress.Any));
+            Assert.ThrowsAny<InvalidOperationException>(() => new LookupClient(IPAddress.Any, 33));
+            Assert.ThrowsAny<InvalidOperationException>(() => new LookupClient(IPAddress.IPv6Any));
+            Assert.ThrowsAny<InvalidOperationException>(() => new LookupClient(IPAddress.IPv6Any, 555));
+        }
+
+        [Fact]
+        public void ValidateAnyAddress_LookupClientQuery()
+        {
+            var client = new LookupClient(NameServer.Cloudflare);
+
+            Assert.ThrowsAny<InvalidOperationException>(() => client.QueryServer(new[] { IPAddress.Any }, "query", QueryType.A));
+            Assert.ThrowsAny<InvalidOperationException>(() => client.QueryServerReverse(new[] { IPAddress.Any }, IPAddress.Loopback));
+        }
+
+        [Fact]
+        public async Task ValidateAnyAddress_LookupClientQueryAsync()
+        {
+            var client = new LookupClient(NameServer.Cloudflare);
+
+            await Assert.ThrowsAnyAsync<InvalidOperationException>(() => client.QueryServerAsync(new[] { IPAddress.Any }, "query", QueryType.A));
+            await Assert.ThrowsAnyAsync<InvalidOperationException>(() => client.QueryServerReverseAsync(new[] { IPAddress.Any }, IPAddress.Loopback));
+        }
     }
 }


### PR DESCRIPTION
This change will remove and name server using the IPv4 or IPv6 ANY address and either log a warning or throw an error in case there is no other server configured to use.

Fixes #74 