### PR TITLE
Changing behavior for header ID miss-matches to log warnings

### DIFF
--- a/src/DnsClient/DnsTcpMessageHandler.cs
+++ b/src/DnsClient/DnsTcpMessageHandler.cs
@@ -167,10 +167,6 @@ namespace DnsClient
                     }
 
                     DnsResponseMessage response = GetResponseMessage(new ArraySegment<byte>(memory.Buffer, 0, bytesReceived));
-                    if (request.Header.Id != response.Header.Id)
-                    {
-                        throw new DnsResponseException("Header id mismatch.");
-                    }
 
                     responses.Add(response);
                 }

--- a/src/DnsClient/DnsUdpMessageHandler.cs
+++ b/src/DnsClient/DnsUdpMessageHandler.cs
@@ -51,10 +51,6 @@ namespace DnsClient
                     var received = udpClient.Client.Receive(memory.Buffer, 0, readSize, SocketFlags.None);
 
                     var response = GetResponseMessage(new ArraySegment<byte>(memory.Buffer, 0, received));
-                    if (request.Header.Id != response.Header.Id)
-                    {
-                        throw new DnsResponseException("Header id mismatch.");
-                    }
 
                     Enqueue(server.AddressFamily, udpClient);
 
@@ -126,10 +122,6 @@ namespace DnsClient
 
                     var response = GetResponseMessage(new ArraySegment<byte>(result.Buffer, 0, result.Buffer.Length));
 #endif
-                    if (request.Header.Id != response.Header.Id)
-                    {
-                        throw new DnsResponseException("Header id mismatch.");
-                    }
 
                     Enqueue(endpoint.AddressFamily, udpClient);
 

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -1471,7 +1471,10 @@ namespace DnsClient
 
             if (request.Header.Id != response.Header.Id)
             {
-                throw new DnsResponseException("Header id mismatch.");
+                _logger.LogWarning(
+                    "Request header id {0} does not match response header {1}. This might be due to some non-standard configuration in your network.",
+                    request.Header.Id,
+                    response.Header.Id);
             }
 
             audit?.AuditResolveServers(serverCount);


### PR DESCRIPTION
Changing behavior for header ID miss-matches to log warnings instead of throwing a hard error.´

Fixes #79 