### PR TITLE
Added TLSA record support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ var ip = record?.Address;
 
 ### Supported resource records
 
-* A, AAAA, NS, CNAME, SOA, MB, MG, MR, WKS, HINFO, MINFO, MX, RP, TXT, AFSDB, URI, CAA, NULL, SSHFP
+* A, AAAA, NS, CNAME, SOA, MB, MG, MR, WKS, HINFO, MINFO, MX, RP, TXT, AFSDB, URI, CAA, NULL, SSHFP, TLSA
 * PTR for reverse lookups
 * SRV for service discovery. `LookupClient` has some extensions to help with that.
 * AXFR zone transfer (as per spec, LookupClient has to be set to TCP mode only for this type. Also, the result depends on if the DNS server trusts your current connection)

--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -247,9 +247,9 @@ namespace DnsClient
 
         private DnsResourceRecord ResolveTlsaRecord(ResourceRecordInfo info)
         {
-            var certificateUsage = _reader.ReadByte();
-            var selector = _reader.ReadByte();
-            var matchingType = _reader.ReadByte();
+            var certificateUsage = (TlsaCertificateUsage) _reader.ReadByte();
+            var selector = (TlsaSelector) _reader.ReadByte();
+            var matchingType = (TlsaMatchingType) _reader.ReadByte();
             var certificateAssociationData = _reader.ReadBytes(info.RawDataLength - 3).ToArray();
             return new TlsaRecord(info, certificateUsage, selector, matchingType, certificateAssociationData);
         }

--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -135,6 +135,10 @@ namespace DnsClient
                     result = ResolveOptRecord(info);
                     break;
 
+                case ResourceRecordType.TLSA:
+                    result = ResolveTlsaRecord(info);
+                    break;
+
                 case ResourceRecordType.URI:
                     result = ResolveUriRecord(info);
                     break;
@@ -239,6 +243,15 @@ namespace DnsClient
             var fingerprint = _reader.ReadBytes(info.RawDataLength - 2).ToArray();
             var fingerprintHexString = string.Join(string.Empty, fingerprint.Select(b => b.ToString("X2")));
             return new SshfpRecord(info, algorithm, fingerprintType, fingerprintHexString);
+        }
+
+        private DnsResourceRecord ResolveTlsaRecord(ResourceRecordInfo info)
+        {
+            var certificateUsage = _reader.ReadByte();
+            var selector = _reader.ReadByte();
+            var matchingType = _reader.ReadByte();
+            var certificateAssociationData = _reader.ReadBytes(info.RawDataLength - 3).ToArray();
+            return new TlsaRecord(info, certificateUsage, selector, matchingType, certificateAssociationData);
         }
 
         private DnsResourceRecord ResolveCaaRecord(ResourceRecordInfo info)

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -181,6 +181,13 @@ namespace DnsClient.Protocol
         RRSIG = 46,
 
         /// <summary>
+        /// TLSA rfc6698.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698">RFC 6698</seealso>
+        /// <seealso cref="TlsaRecord"/>
+        TLSA = 52,
+
+        /// <summary>
         /// A Uniform Resource Identifier (URI) resource record.
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc7553">RFC 7553</seealso>

--- a/src/DnsClient/Protocol/TlsaRecord.cs
+++ b/src/DnsClient/Protocol/TlsaRecord.cs
@@ -35,7 +35,7 @@ namespace DnsClient.Protocol
         /// the TLS handshake.
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.1">RFC 6698</seealso>
-        public byte CertificateUsage { get; }
+        public TlsaCertificateUsage CertificateUsage { get; }
 
         /// <summary>
         /// A one-octet value, called "selector", specifies which part of the TLS
@@ -45,7 +45,7 @@ namespace DnsClient.Protocol
         /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.2">RFC 6698</seealso>
         /// <seealso href="https://tools.ietf.org/html/rfc5280">RFC 5280</seealso>
         /// <seealso href="https://tools.ietf.org/html/rfc6376">RFC 6376</seealso>
-        public byte Selector { get; }
+        public TlsaSelector Selector { get; }
 
         /// <summary>
         /// A one-octet value, called "matching type", specifies how the
@@ -53,7 +53,7 @@ namespace DnsClient.Protocol
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.3">RFC 6698</seealso>
         /// <seealso href="https://tools.ietf.org/html/rfc6234">RFC 6234</seealso>
-        public byte MatchingType { get; }
+        public TlsaMatchingType MatchingType { get; }
 
         /// <summary>
         /// This field specifies the "certificate association data" to be
@@ -78,7 +78,7 @@ namespace DnsClient.Protocol
         /// <param name="matchingType">The matching type.</param>
         /// <param name="certificateAssociationData">Certificate association data.</param>
         /// <exception cref="System.ArgumentNullException">If <paramref name="certificateAssociationData"/> or <paramref name="info"/> is null.</exception>
-        public TlsaRecord(ResourceRecordInfo info, byte certificateUsage, byte selector, byte matchingType, byte[] certificateAssociationData)
+        public TlsaRecord(ResourceRecordInfo info, TlsaCertificateUsage certificateUsage, TlsaSelector selector, TlsaMatchingType matchingType, byte[] certificateAssociationData)
             : base(info)
         {
             CertificateUsage = certificateUsage;
@@ -96,5 +96,68 @@ namespace DnsClient.Protocol
                 MatchingType,
                 CertificateAssociationDataAsString);
         }
+    }
+
+    /// <summary>
+    /// Certificate usage used by <see cref="TlsaRecord"/>
+    /// </summary>
+    public enum TlsaCertificateUsage
+    {
+        /// <summary>
+        /// Certificate Authority Constraint
+        /// </summary>
+        PKIX_TA = 0,
+
+        /// <summary>
+        /// Service Certificate Constraint
+        /// </summary>
+        PKIX_EE = 1,
+
+        /// <summary>
+        /// Trust Anchor Assertion
+        /// </summary>
+        DANE_TA = 2,
+
+        /// <summary>
+        /// Domain Issued Certificate
+        /// </summary>
+        DANE_EE = 3,
+    }
+
+    /// <summary>
+    /// Selector used by <see cref="TlsaRecord"/>
+    /// </summary>
+    public enum TlsaSelector
+    {
+        /// <summary>
+        /// Use full certificate
+        /// </summary>
+        CERT = 0,
+
+        /// <summary>
+        /// Use subject public key
+        /// </summary>
+        SPKI = 1,
+    }
+
+    /// <summary>
+    /// Matching type used by <see cref="TlsaRecord"/>
+    /// </summary>
+    public enum TlsaMatchingType
+    {
+        /// <summary>
+        /// No Hash
+        /// </summary>
+        FULL = 0,
+
+        /// <summary>
+        /// SHA-256 hash
+        /// </summary>
+        SHA256 = 1,
+
+        /// <summary>
+        /// SHA-512 hash
+        /// </summary>
+        SHA512 = 2,
     }
 }

--- a/src/DnsClient/Protocol/TlsaRecord.cs
+++ b/src/DnsClient/Protocol/TlsaRecord.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq;
+
+namespace DnsClient.Protocol
+{
+    /* https://tools.ietf.org/html/rfc6698#section-2.1
+    2.1.  TLSA RDATA Wire Format
+
+    The RDATA for a TLSA RR consists of a one-octet certificate usage
+    field, a one-octet selector field, a one-octet matching type field,
+    and the certificate association data field.
+
+                            1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        |  Cert. Usage  |   Selector    | Matching Type |               /
+        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+               /
+        /                                                               /
+        /                 Certificate Association Data                  /
+        /                                                               /
+        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+    */
+
+    /// <summary>
+    /// A <see cref="DnsResourceRecord"/> representing a TLSA record.
+    /// </summary>
+    /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1">RFC 6698</seealso>
+    [CLSCompliant(false)]
+    public class TlsaRecord : DnsResourceRecord
+    {
+        /// <summary>
+        /// A one-octet value, called "certificate usage", specifies the provided
+        /// association that will be used to match the certificate presented in
+        /// the TLS handshake.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.1">RFC 6698</seealso>
+        public byte CertificateUsage { get; }
+
+        /// <summary>
+        /// A one-octet value, called "selector", specifies which part of the TLS
+        /// certificate presented by the server will be matched against the
+        /// association data.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.2">RFC 6698</seealso>
+        /// <seealso href="https://tools.ietf.org/html/rfc5280">RFC 5280</seealso>
+        /// <seealso href="https://tools.ietf.org/html/rfc6376">RFC 6376</seealso>
+        public byte Selector { get; }
+
+        /// <summary>
+        /// A one-octet value, called "matching type", specifies how the
+        /// certificate association is presented.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.3">RFC 6698</seealso>
+        /// <seealso href="https://tools.ietf.org/html/rfc6234">RFC 6234</seealso>
+        public byte MatchingType { get; }
+
+        /// <summary>
+        /// This field specifies the "certificate association data" to be
+        /// matched.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.4">RFC 6698</seealso>
+        public byte[] CertificateAssociationData { get; }
+
+        /// <summary>
+        /// This field specifies the "certificate association data" to be
+        /// matched. Represented as hex-encoded lowercase string.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698#section-2.1.4">RFC 6698</seealso>
+        public string CertificateAssociationDataAsString { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TlsaRecord"/> class.
+        /// </summary>
+        /// <param name="info">The information.</param>
+        /// <param name="certificateUsage">The certification usage.</param>
+        /// <param name="selector">The selector.</param>
+        /// <param name="matchingType">The matching type.</param>
+        /// <param name="certificateAssociationData">Certificate association data.</param>
+        /// <exception cref="System.ArgumentNullException">If <paramref name="certificateAssociationData"/> or <paramref name="info"/> is null.</exception>
+        public TlsaRecord(ResourceRecordInfo info, byte certificateUsage, byte selector, byte matchingType, byte[] certificateAssociationData)
+            : base(info)
+        {
+            CertificateUsage = certificateUsage;
+            Selector = selector;
+            MatchingType = matchingType;
+            CertificateAssociationData = certificateAssociationData ?? throw new ArgumentNullException(nameof(certificateAssociationData));
+            CertificateAssociationDataAsString = string.Join(string.Empty, CertificateAssociationData.Select(b => b.ToString("x2")));
+        }
+
+        private protected override string RecordToString()
+        {
+            return string.Format("{0} {1} {2} {3}", 
+                CertificateUsage,
+                Selector,
+                MatchingType,
+                CertificateAssociationDataAsString);
+        }
+    }
+}

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -163,6 +163,13 @@ namespace DnsClient
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc3755">RFC 3755</seealso>
         RRSIG = ResourceRecordType.RRSIG,
+        
+        /// <summary>
+        /// TLSA rfc6698.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc6698">RFC 6698</seealso>
+        /// <seealso cref="TlsaRecord"/>
+        TLSA = ResourceRecordType.TLSA,
 
         /// <summary>
         /// DNS zone transfer request.

--- a/src/DnsClient/ResourceRecordCollectionExtensions.cs
+++ b/src/DnsClient/ResourceRecordCollectionExtensions.cs
@@ -193,6 +193,17 @@ namespace System.Linq
         }
 
         /// <summary>
+        /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="TlsaRecord"/>s only.
+        /// </summary>
+        /// <param name="records">The records.</param>
+        /// <returns>The list of <see cref="TlsaRecord"/>.</returns>
+        [CLSCompliant(false)]
+        public static IEnumerable<TlsaRecord> TlsaRecords(this IEnumerable<DnsResourceRecord> records)
+        {
+            return records.OfType<TlsaRecord>();
+        }
+
+        /// <summary>
         /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="UriRecord"/>s only.
         /// </summary>
         /// <param name="records">The records.</param>


### PR DESCRIPTION
### Sample code

``` csharp
var lookup = new LookupClient();
var result = lookup.Query("_443._tcp.monicz.pl", QueryType.TLSA);
var record = result.Answers.TlsaRecords().ToArray();
```

![200828180453_devenv_f85342](https://user-images.githubusercontent.com/10835147/91588795-009ef500-e959-11ea-8ff1-252db76403cb.png)

### Notes

One of the tests is failing because current test [`ZoneData`](https://github.com/MichaCo/DnsClient.NET/blob/dev/test/DnsClient.Tests/DnsResponseParsingTest.cs#L321) does not contain a response for it (TLSA record). Instead of skipping the check I've decided to leave it as it is as you may add response for it in later time. I am simply not as advanced to modify the `ZoneData` by myself without breaking it 8) Except for that everything works as intended.

![200828180747_devenv_9008a0](https://user-images.githubusercontent.com/10835147/91589040-61c6c880-e959-11ea-8db6-1936e596b5d5.png)