### PR TITLE
Adding NSEC3 records

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ var ip = record?.Address;
   * Minimum TTL setting to overrule the result's TTL and always cache the responses for at least that time. (Even very low value, like a few milliseconds, do make a huge difference if used in high traffic low latency scenarios)
   * Maximum TTL to limit cache duration
   * Cache can be disabled
+* Nameserver auto discovery. If no servers are explicitly configured, DnsClient will try its best to resolve them based on your local system configuration.
+  This includes DNS servers configured via network interfaces or even via Windows specific [NRPT policies](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnrpt/8cc31cb9-20cb-4140-9e85-3e08703b4745).
 * Multiple DNS endpoints can be configured. DnsClient will use them in random or sequential order (configurable), with re-tries.
 * Configurable retry of queries
 * Optional audit trail of each response and exception
@@ -42,32 +44,19 @@ var ip = record?.Address;
 
 ### Supported resource records
 
-* A, AAAA, NS, CNAME, SOA, MB, MG, MR, WKS, HINFO, MINFO, MX, RP, TXT, AFSDB, URI, CAA, NULL, SSHFP, TLSA, RRSIG, NSEC, DNSKEY, DS
+* A, AAAA, NS, CNAME, SOA, MB, MG, MR, WKS, HINFO, MINFO, MX, RP, TXT, AFSDB, URI, CAA, NULL, SSHFP, TLSA, RRSIG, NSEC, NSEC3, NSEC3PARAM, DNSKEY, DS
 * PTR for reverse lookups
 * SRV for service discovery. `LookupClient` has some extensions to help with that.
 * AXFR zone transfer (as per spec, LookupClient has to be set to TCP mode only for this type. Also, the result depends on if the DNS server trusts your current connection)
 
 ## Build from Source
 
-The solution requires a .NET Core 3.x SDK and the [.NET 4.7.1 Dev Pack](https://www.microsoft.com/net/download/dotnet-framework/net471) being installed.
-
-Just clone the repository and open the solution in Visual Studio 2017/2019.
-
-The unit tests don't require any additional setup right now.
-
-If you want to test the different record types, there are config files for Bind under tools. 
-Just [download Bind](https://www.isc.org/downloads/) for Windows and copy the binaries to tools/BIND, then run bind.cmd.
-If you are running this on Linux, you can use my config files and replace the default ones if you want.
-
-Now, you can use **samples/MiniDig** to query the local DNS server. 
-The following should return many different resource records:
-
-``` cmd
-dotnet run -s localhost mcnet.com any
-```
+To build and contribute to this project, you must have the latest [.NET 5 SDK](https://dotnet.microsoft.com/download) installed.
+Just clone the repository and open the solution in Visual Studio 2019.
 
 ## Examples
 
+* See [MiniDig](https://github.com/MichaCo/DnsClient.NET/tree/dev/samples/MiniDig)'s readme for what this example command line tool can do.
 * More documentation and a simple query window on http://dnsclient.michaco.net
 * The [Samples](https://github.com/MichaCo/DnsClient.NET.Samples) repository (there might be more in the future).
-* [MiniDig](https://github.com/MichaCo/DnsClient.NET/tree/dev/samples/MiniDig)
+

--- a/samples/MiniDig/readme.md
+++ b/samples/MiniDig/readme.md
@@ -5,19 +5,62 @@ It is supposed to work similar to the well-known `dig` command line tool on Linu
 ## How to Build/Run it
 To run it, open a command line windows, or bash, navigate to `/Samples/MiniDig` and run `dotnet restore` and `dotnet run`.
 
-MiniDig is multi targeted for now, which means, when you use `dotnet run` you have to specify a framework 
-`-f NetCoreApp2.0` or `-f net472` for example.
+MiniDig is targeting .NET5 and will run on any supported platform as long as the .NET5 SDK or runtime is installed.
 
 ## Examples
-`dotnet run -f netcoreapp2.0 google.com ANY` to query for google.com
+`dotnet run google.com ANY` to query for google.com
+
+Example output:
+```csharp
+; <<>> MiniDiG 1.0.0.0 Microsoft Windows 10.0.19042 <<>> google.com any
+; Servers: 192.168.0.2:53
+; (1 server found)
+;; Got answer:
+;; ->>HEADER<<- opcode: Query, status: No Error, id: 39207
+;; flags: qr rd ra; QUERY: 1, ANSWER: 22, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; UDP: 1472; code: NoError
+;; QUESTION SECTION:
+google.com.                             IN      ANY
+
+;; ANSWER SECTION:
+google.com.  1195    IN      A       216.58.207.142
+google.com.  1195    IN      AAAA    2a00:1450:4016:806::200e
+google.com.  1195    IN      SOA     ns1.google.com. dns-admin.google.com. 375442030 900 900 1800 60
+google.com.  345595  IN      NS      ns2.google.com.
+google.com.  345595  IN      NS      ns4.google.com.
+google.com.  345595  IN      NS      ns3.google.com.
+google.com.  345595  IN      NS      ns1.google.com.
+google.com.  86395   IN      CAA     0 issue "pki.goog"
+google.com.  3595    IN      TXT     "docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e"
+google.com.  3595    IN      TXT     "docusign=1b0a6754-49b1-4db5-8540-d2c12664b289"
+google.com.  3595    IN      TXT     "facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95"
+google.com.  3595    IN      TXT     "google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ"
+google.com.  3595    IN      TXT     "MS=E4A68B9AB2BB9670BCE15412F62916164C0B20BB"
+google.com.  3595    IN      TXT     "globalsign-smime-dv=CDYX+XFHUw2wml6/Gb8+59BsH31KzUr6c1l2BPvqKX8="
+google.com.  3595    IN      TXT     "google-site-verification=wD8N7i1JTNTkezJ49swvWW48f8_9xveREV4oB-0Hf5o"
+google.com.  3595    IN      TXT     "apple-domain-verification=30afIBcvSuDV2PLX"
+google.com.  3595    IN      TXT     "v=spf1 include:_spf.google.com ~all"
+google.com.  1195    IN      MX      10 aspmx.l.google.com.
+google.com.  1195    IN      MX      20 alt1.aspmx.l.google.com.
+google.com.  1195    IN      MX      30 alt2.aspmx.l.google.com.
+google.com.  1195    IN      MX      40 alt3.aspmx.l.google.com.
+google.com.  1195    IN      MX      50 alt4.aspmx.l.google.com.
+
+;; Query time: 58 msec
+;; SERVER: 192.168.0.2#53
+;; WHEN: Mon May 24 21:52:45 Z 2021
+;; MSG SIZE  rcvd: 922
+```
 
 If nothing else is specified, it uses the DNS server configured for your local network adapter.
 To specify a different server, use the `-s` switch, for example:
 
-`dotnet run -f netcoreapp2.0 -s 8.8.8.8 google.com` to use the public Google name server.
+`dotnet run -s 8.8.8.8 google.com` to use the public Google name server.
 
 
-`dotnet run -f netcoreapp2.0 -s 127.0.0.1#8600` to also specify a custom port.
+`dotnet run -s 127.0.0.1#8600` to also specify a custom port.
 
 
 ## Performance Testing

--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -163,6 +163,10 @@ namespace DnsClient
                     result = ResolveNSec3Record(info);
                     break;
 
+                case ResourceRecordType.NSEC3PARAM: // 51
+                    result = ResolveNSec3ParamRecord(info);
+                    break;
+
                 case ResourceRecordType.TLSA: // 52
                     result = ResolveTlsaRecord(info);
                     break;
@@ -322,6 +326,16 @@ namespace DnsClient
             var nextOwnersName = _reader.ReadBytes(nextOwnerLength).ToArray();
             var bitMaps = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
             return new NSec3Record(info, hashAlgorithm, flags, iterations, salt, nextOwnersName, bitMaps);
+        }
+
+        private DnsResourceRecord ResolveNSec3ParamRecord(ResourceRecordInfo info)
+        {
+            var hashAlgorithm = _reader.ReadByte();
+            var flags = _reader.ReadByte();
+            var iterations = _reader.ReadUInt16NetworkOrder();
+            var saltLength = _reader.ReadByte();
+            var salt = _reader.ReadBytes(saltLength).ToArray();
+            return new NSec3ParamRecord(info, hashAlgorithm, flags, iterations, salt);
         }
 
         private DnsResourceRecord ResolveDnsKeyRecord(ResourceRecordInfo info)

--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -159,6 +159,10 @@ namespace DnsClient
                     result = ResolveDnsKeyRecord(info);
                     break;
 
+                case ResourceRecordType.NSEC3: // 50
+                    result = ResolveNSec3Record(info);
+                    break;
+
                 case ResourceRecordType.TLSA: // 52
                     result = ResolveTlsaRecord(info);
                     break;
@@ -304,6 +308,20 @@ namespace DnsClient
             var nextName = _reader.ReadDnsName();
             var bitMaps = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
             return new NSecRecord(info, nextName, bitMaps);
+        }
+
+        private DnsResourceRecord ResolveNSec3Record(ResourceRecordInfo info)
+        {
+            var startIndex = _reader.Index;
+            var hashAlgorithm = _reader.ReadByte();
+            var flags = _reader.ReadByte();
+            var iterations = _reader.ReadUInt16NetworkOrder();
+            var saltLength = _reader.ReadByte();
+            var salt = _reader.ReadBytes(saltLength).ToArray();
+            var nextOwnerLength = _reader.ReadByte();
+            var nextOwnersName = _reader.ReadBytes(nextOwnerLength).ToArray();
+            var bitMaps = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
+            return new NSec3Record(info, hashAlgorithm, flags, iterations, salt, nextOwnersName, bitMaps);
         }
 
         private DnsResourceRecord ResolveDnsKeyRecord(ResourceRecordInfo info)

--- a/src/DnsClient/Internal/Base32Hex.cs
+++ b/src/DnsClient/Internal/Base32Hex.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Linq;
+
+namespace DnsClient.Internal
+{
+    /// <summary>
+    /// Base32 encoder with the extended hey alphabet
+    /// </summary>
+    /// <remarks>
+    /// See https://datatracker.ietf.org/doc/html/rfc4648#section-7
+    /// <![CDATA[
+    ///              Table 4: The "Extended Hex" Base 32 Alphabet
+    ///
+    ///     Value Encoding  Value Encoding  Value Encoding  Value Encoding
+    ///         0 0             9 9            18 I            27 R
+    ///         1 1            10 A            19 J            28 S
+    ///         2 2            11 B            20 K            29 T
+    ///         3 3            12 C            21 L            30 U
+    ///         4 4            13 D            22 M            31 V
+    ///         5 5            14 E            23 N
+    ///         6 6            15 F            24 O         (pad) =
+    ///         7 7            16 G            25 P
+    ///         8 8            17 H            26 Q
+    ///
+    /// ]]>
+    /// </remarks>
+    /// <seealso href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC4648</seealso>
+    public static class Base32Hex
+    {
+        /// <summary>
+        /// Converts the specified string, which encodes binary data as base-32 digits
+        /// using the extended hex alphabet, to an equivalent 8-bit unsigned integer array.
+        /// </summary>
+        /// <param name="input">The string to convert.</param>
+        /// <returns>An array of 8-bit unsigned integers that is equivalent to <paramref name="input"/>.</returns>
+        public static byte[] FromBase32HexString(string input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (input.Length == 0)
+            {
+                return new byte[0];
+            }
+
+            input = input.TrimEnd('=');
+            var byteCount = input.Length * 5 / 8;
+            var result = new byte[byteCount];
+            byte currentByte = 0, bitsRemaining = 8;
+            var arrayIndex = 0;
+            foreach (var value in input.Select(CharToValue))
+            {
+                int mask;
+                if (bitsRemaining > 5)
+                {
+                    mask = value << (bitsRemaining - 5);
+                    currentByte = (byte)(currentByte | mask);
+                    bitsRemaining -= 5;
+                }
+                else
+                {
+                    mask = value >> (5 - bitsRemaining);
+                    currentByte = (byte)(currentByte | mask);
+                    result[arrayIndex++] = currentByte;
+                    unchecked
+                    {
+                        currentByte = (byte)(value << (3 + bitsRemaining));
+                    }
+                    bitsRemaining += 3;
+                }
+            }
+            if (arrayIndex != byteCount)
+            {
+                result[arrayIndex] = currentByte;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts an array of 8-bit unsigned integers to its equivalent string
+        /// representation that is encoded with base-32 digits using the extended hex alphabet.
+        /// </summary>
+        /// <param name="input">An array of 8-bit unsigned integers.</param>
+        /// <returns>The string representation in base 32 hex of <paramref name="input"/>.</returns>
+        public static string ToBase32HexString(byte[] input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (input.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var charCount = (int)Math.Ceiling(input.Length / 5d) * 8;
+            var result = new char[charCount];
+            byte nextChar = 0, bitsRemaining = 5;
+            var arrayIndex = 0;
+            foreach (var b in input)
+            {
+                nextChar = (byte)(nextChar | (b >> (8 - bitsRemaining)));
+                result[arrayIndex++] = ValueToChar(nextChar);
+                if (bitsRemaining < 4)
+                {
+                    nextChar = (byte)((b >> (3 - bitsRemaining)) & 31);
+                    result[arrayIndex++] = ValueToChar(nextChar);
+                    bitsRemaining += 5;
+                }
+                bitsRemaining -= 3;
+                nextChar = (byte)((b << bitsRemaining) & 31);
+            }
+            if (arrayIndex == charCount)
+            {
+                return new string(result);
+            }
+
+            result[arrayIndex++] = ValueToChar(nextChar);
+            while (arrayIndex != charCount)
+            {
+                result[arrayIndex++] = '=';
+            }
+
+            return new string(result);
+        }
+
+        private static int CharToValue(char c)
+        {
+            var value = c;
+            if (value <= 58 && value >= 48)
+            {
+                return value - 48;
+            }
+            if (value <= 86 && value >= 65)
+            {
+                return value - 55;
+            }
+
+            throw new ArgumentException("Character is not a Base32 character.", nameof(c));
+        }
+
+        private static char ValueToChar(byte b)
+        {
+            if (b < 10)
+            {
+                return (char)(b + 48);
+            }
+            if (b <= 32)
+            {
+                return (char)(b + 55);
+            }
+
+            throw new ArgumentException("Byte is not a value Base32 value.", nameof(b));
+        }
+    }
+}

--- a/src/DnsClient/Protocol/NSec3ParamRecord.cs
+++ b/src/DnsClient/Protocol/NSec3ParamRecord.cs
@@ -83,7 +83,7 @@ namespace DnsClient.Protocol
             HashAlgorithm = hashAlgorithm;
             Flags = flags;
             Iterations = iterations;
-            Salt = salt;
+            Salt = salt ?? throw new ArgumentNullException(nameof(salt));
             SaltAsString = Salt.Length == 0 ? "-" : string.Join(string.Empty, Salt.Select(b => b.ToString("X2")));
         }
 

--- a/src/DnsClient/Protocol/NSec3ParamRecord.cs
+++ b/src/DnsClient/Protocol/NSec3ParamRecord.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq;
+
+namespace DnsClient.Protocol
+{
+    /* https://datatracker.ietf.org/doc/html/rfc5155#section-4.2
+    NSEC3PARAM RDATA Wire Format
+
+       The RDATA of the NSEC3PARAM RR is as shown below:
+
+                            1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hash Alg.   |     Flags     |          Iterations           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |  Salt Length  |                     Salt                      /
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+       Hash Algorithm is a single octet.
+
+       Flags field is a single octet.
+
+       Iterations is represented as a 16-bit unsigned integer, with the most
+       significant bit first.
+
+       Salt Length is represented as an unsigned octet.  Salt Length
+       represents the length of the following Salt field in octets.  If the
+       value is zero, the Salt field is omitted.
+
+       Salt, if present, is encoded as a sequence of binary octets.  The
+       length of this field is determined by the preceding Salt Length
+       field.
+    */
+
+    /// <summary>
+    /// a <see cref="DnsResourceRecord"/> representing a NSEC3PARAM record.
+    /// </summary>
+    /// <seealso href="https://datatracker.ietf.org/doc/html/rfc5155#section-4"/>
+    /// <see cref="ResourceRecordType.NSEC3PARAM"/>
+    public class NSec3ParamRecord : DnsResourceRecord
+    {
+        /// <summary>
+        /// Gets the cryptographic hash algorithm used to construct the hash-value.
+        /// </summary>
+        public byte HashAlgorithm { get; }
+
+        /// <summary>
+        /// Gets the flags field value containing 8 one-bit flags that can be used to indicate different processing.
+        /// All undefined flags must be zero.
+        /// The only flag defined by this specification is the Opt-Out flag.
+        /// </summary>
+        public byte Flags { get; }
+
+        /// <summary>
+        /// Gets the number of additional times the hash function has been performed.
+        /// </summary>
+        public int Iterations { get; }
+
+        /// <summary>
+        /// Gets the salt field which is appended to the original owner name before hashing
+        /// in order to defend against pre-calculated dictionary attacks.
+        /// </summary>
+        public byte[] Salt { get; }
+
+        /// <summary>
+        /// Gets the salt field which is appended to the original owner name before hashing
+        /// in order to defend against pre-calculated dictionary attacks.
+        /// </summary>
+        public string SaltAsString { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NSec3ParamRecord"/> class
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="info"/> or <paramref name="salt"/> is null.</exception>
+        public NSec3ParamRecord(
+            ResourceRecordInfo info,
+            byte hashAlgorithm,
+            byte flags,
+            int iterations,
+            byte[] salt)
+            : base(info)
+        {
+            HashAlgorithm = hashAlgorithm;
+            Flags = flags;
+            Iterations = iterations;
+            Salt = salt;
+            SaltAsString = Salt.Length == 0 ? "-" : string.Join(string.Empty, Salt.Select(b => b.ToString("X2")));
+        }
+
+        private protected override string RecordToString()
+        {
+            return string.Format(
+                "{0} {1} {2} {3}",
+                HashAlgorithm,
+                Flags,
+                Iterations,
+                SaltAsString);
+        }
+    }
+}

--- a/src/DnsClient/Protocol/NSec3Record .cs
+++ b/src/DnsClient/Protocol/NSec3Record .cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using DnsClient.Internal;
+
+namespace DnsClient.Protocol
+{
+    /* https://datatracker.ietf.org/doc/html/rfc5155#section-3.2
+    3.2.  NSEC3 RDATA Wire Format
+
+       The RDATA of the NSEC3 RR is as shown below:
+
+                            1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hash Alg.   |     Flags     |          Iterations           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |  Salt Length  |                     Salt                      /
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |  Hash Length  |             Next Hashed Owner Name            /
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       /                         Type Bit Maps                         /
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+       Hash Algorithm is a single octet.
+
+       Flags field is a single octet, the Opt-Out flag is the least
+       significant bit, as shown below:
+
+        0 1 2 3 4 5 6 7
+       +-+-+-+-+-+-+-+-+
+       |             |O|
+       +-+-+-+-+-+-+-+-+
+
+    */
+
+    /// <summary>
+    /// a <see cref="DnsResourceRecord"/> representing a NSEC3 record.
+    /// </summary>
+    /// <seealso href="https://datatracker.ietf.org/doc/html/rfc5155"/>
+    public class NSec3Record : DnsResourceRecord
+    {
+        /// <summary>
+        /// Gets the cryptographic hash algorithm used to construct the hash-value.
+        /// </summary>
+        public byte HashAlgorithm { get; }
+
+        /// <summary>
+        /// Gets the flags field value containing 8 one-bit flags that can be used to indicate different processing.
+        /// All undefined flags must be zero.
+        /// The only flag defined by this specification is the Opt-Out flag.
+        /// </summary>
+        public byte Flags { get; }
+
+        /// <summary>
+        /// Gets the number of additional times the hash function has been performed.
+        /// </summary>
+        public int Iterations { get; }
+
+        /// <summary>
+        /// Gets the salt field which is appended to the original owner name before hashing
+        /// in order to defend against pre-calculated dictionary attacks.
+        /// </summary>
+        public byte[] Salt { get; }
+
+        /// <summary>
+        /// Gets the salt field which is appended to the original owner name before hashing
+        /// in order to defend against pre-calculated dictionary attacks.
+        /// </summary>
+        public string SaltAsString { get; }
+
+        /// <summary>
+        /// Gets the name of the next hashed owner in hash order.
+        /// This value is in binary format.
+        /// </summary>
+        public byte[] NextOwnersName { get; }
+
+        /// <summary>
+        /// Gets the name of the next hashed owner in hash order.
+        /// This value is in binary format.
+        /// </summary>
+        public string NextOwnersNameAsString { get; }
+
+        /// <summary>
+        /// Gets the type bit maps field which identifies the RRSet types that exist at the original owner name of the NSEC3 RR.
+        /// </summary>
+        public IReadOnlyList<byte> TypeBitMapsRaw { get; }
+
+        /// <summary>
+        /// Gets the type bit maps field which identifies the RRSet types that exist at the original owner name of the NSEC3 RR.
+        /// </summary>
+        public IReadOnlyList<ResourceRecordType> TypeBitMaps { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NSecRecord"/> class
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="info"/>, <paramref name="nextOwnersName"/> or <paramref name="bitmap"/> is null.</exception>
+        public NSec3Record(
+            ResourceRecordInfo info,
+            byte hashAlgorithm,
+            byte flags,
+            int iterations,
+            byte[] salt,
+            byte[] nextOwnersName,
+            byte[] bitmap)
+            : base(info)
+        {
+            HashAlgorithm = hashAlgorithm;
+            Flags = flags;
+            Iterations = iterations;
+            Salt = salt;
+            SaltAsString = Salt.Length == 0 ? "-" : string.Join(string.Empty, Salt.Select(b => b.ToString("X2")));
+            NextOwnersName = nextOwnersName;
+
+            try
+            {
+                NextOwnersNameAsString = Base32Hex.ToBase32HexString(nextOwnersName);
+            }
+            catch
+            {
+                // Nothing - I'm just not trusting myself
+            }
+
+            TypeBitMapsRaw = bitmap;
+            TypeBitMaps = NSecRecord.ReadBitmap(bitmap).OrderBy(p => p).Select(p => (ResourceRecordType)p).ToArray();
+            using var sha = SHA1.Create();
+        }
+
+        private protected override string RecordToString()
+        {
+            return string.Format(
+                "{0} {1} {2} {3} {4} {5}",
+                HashAlgorithm,
+                Flags,
+                Iterations,
+                SaltAsString,
+                NextOwnersNameAsString,
+                string.Join(" ", TypeBitMaps));
+        }
+    }
+}

--- a/src/DnsClient/Protocol/NSec3Record .cs
+++ b/src/DnsClient/Protocol/NSec3Record .cs
@@ -110,9 +110,11 @@ namespace DnsClient.Protocol
             HashAlgorithm = hashAlgorithm;
             Flags = flags;
             Iterations = iterations;
-            Salt = salt;
+            Salt = salt ?? throw new ArgumentNullException(nameof(salt));
+            TypeBitMapsRaw = bitmap ?? throw new ArgumentNullException(nameof(bitmap));
+
             SaltAsString = Salt.Length == 0 ? "-" : string.Join(string.Empty, Salt.Select(b => b.ToString("X2")));
-            NextOwnersName = nextOwnersName;
+            NextOwnersName = nextOwnersName ?? throw new ArgumentNullException(nameof(nextOwnersName));
 
             try
             {
@@ -123,7 +125,6 @@ namespace DnsClient.Protocol
                 // Nothing - I'm just not trusting myself
             }
 
-            TypeBitMapsRaw = bitmap;
             TypeBitMaps = NSecRecord.ReadBitmap(bitmap).OrderBy(p => p).Select(p => (ResourceRecordType)p).ToArray();
         }
 

--- a/src/DnsClient/Protocol/NSec3Record .cs
+++ b/src/DnsClient/Protocol/NSec3Record .cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using DnsClient.Internal;
 
 namespace DnsClient.Protocol
@@ -93,9 +92,11 @@ namespace DnsClient.Protocol
         public IReadOnlyList<ResourceRecordType> TypeBitMaps { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NSecRecord"/> class
+        /// Initializes a new instance of the <see cref="NSec3Record"/> class
         /// </summary>
-        /// <exception cref="ArgumentNullException">If <paramref name="info"/>, <paramref name="nextOwnersName"/> or <paramref name="bitmap"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="info"/>, <paramref name="nextOwnersName"/>, <paramref name="salt"/> or <paramref name="bitmap"/> is null.
+        /// </exception>
         public NSec3Record(
             ResourceRecordInfo info,
             byte hashAlgorithm,
@@ -124,7 +125,6 @@ namespace DnsClient.Protocol
 
             TypeBitMapsRaw = bitmap;
             TypeBitMaps = NSecRecord.ReadBitmap(bitmap).OrderBy(p => p).Select(p => (ResourceRecordType)p).ToArray();
-            using var sha = SHA1.Create();
         }
 
         private protected override string RecordToString()

--- a/src/DnsClient/Protocol/NullRecord.cs
+++ b/src/DnsClient/Protocol/NullRecord.cs
@@ -40,7 +40,7 @@ namespace DnsClient.Protocol
         /// </summary>
         /// <param name="info">The information.</param>
         /// <param name="anything">Anything.</param>
-        /// <exception cref="System.ArgumentNullException">If <paramref name="info"/> or <paramref name="anything"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="info"/> or <paramref name="anything"/> is null.</exception>
         public NullRecord(ResourceRecordInfo info, byte[] anything)
             : base(info)
         {

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -211,6 +211,10 @@ namespace DnsClient.Protocol
         /// <seealso href="https://tools.ietf.org/html/rfc5155">RFC 5155</seealso>
         NSEC3 = 50,
 
+        /// <summary>
+        /// NSEC3PARAM rfc5155.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc5155#section-4">RFC 5155</seealso>
         NSEC3PARAM = 51,
 
         /// <summary>

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -206,13 +206,21 @@ namespace DnsClient.Protocol
         DNSKEY = 48,
 
         /// <summary>
+        /// NSEC3 rfc5155.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc5155">RFC 5155</seealso>
+        NSEC3 = 50,
+
+        NSEC3PARAM = 51,
+
+        /// <summary>
         /// TLSA rfc6698.
         /// </summary>
         /// <seealso href="https://https://tools.ietf.org/html/rfc6698">RFC 6698</seealso>
         TLSA = 52,
 
         /// <summary>
-        /// SPF records don't officially have a dedicated RR type, <see cref="ResourceRecordType.TXT"/> should be used instead.
+        /// SPF records don't officially have a dedicated RR type, <see cref="TXT"/> should be used instead.
         /// The behavior of TXT and SPF are the same.
         /// </summary>
         /// <remarks>

--- a/src/DnsClient/Protocol/UnknownRecord.cs
+++ b/src/DnsClient/Protocol/UnknownRecord.cs
@@ -41,7 +41,7 @@ namespace DnsClient.Protocol
         /// </summary>
         /// <param name="info">The information.</param>
         /// <param name="data">The raw data.</param>
-        /// <exception cref="System.ArgumentNullException">If <paramref name="info"/> or <paramref name="data"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="info"/> or <paramref name="data"/> is null.</exception>
         public UnknownRecord(ResourceRecordInfo info, byte[] data)
             : base(info)
         {

--- a/src/DnsClient/Protocol/WksRecord.cs
+++ b/src/DnsClient/Protocol/WksRecord.cs
@@ -110,7 +110,7 @@ namespace DnsClient.Protocol
         /// <param name="address">The address.</param>
         /// <param name="protocol">The protocol.</param>
         /// <param name="bitmap">The raw data.</param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// If <paramref name="address"/> or <paramref name="info"/> or <paramref name="bitmap"/> is null.
         /// </exception>
         public WksRecord(ResourceRecordInfo info, IPAddress address, int protocol, byte[] bitmap)

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -10,7 +10,7 @@ namespace DnsClient
 
     /// <summary>
     /// The query type field appear in the question part of a query.
-    /// Query types are a superset of <see cref="Protocol.ResourceRecordType"/>.
+    /// Query types are a superset of <see cref="ResourceRecordType"/>.
     /// </summary>
     public enum QueryType
     {
@@ -188,6 +188,14 @@ namespace DnsClient
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc4034#section-2">RFC 4034</seealso>
         DNSKEY = ResourceRecordType.DNSKEY,
+
+        /// <summary>
+        /// NSEC3 rfc5155.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc5155">RFC 5155</seealso>
+        NSEC3 = ResourceRecordType.NSEC3,
+
+        NSEC3PARAM = ResourceRecordType.NSEC3PARAM,
 
         /// <summary>
         /// TLSA rfc6698

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -195,6 +195,10 @@ namespace DnsClient
         /// <seealso href="https://tools.ietf.org/html/rfc5155">RFC 5155</seealso>
         NSEC3 = ResourceRecordType.NSEC3,
 
+        /// <summary>
+        /// NSEC3PARAM rfc5155.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc5155#section-4">RFC 5155</seealso>
         NSEC3PARAM = ResourceRecordType.NSEC3PARAM,
 
         /// <summary>

--- a/test/DnsClient.Tests/Base32Test.cs
+++ b/test/DnsClient.Tests/Base32Test.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using DnsClient.Internal;
+using Xunit;
+
+namespace DnsClient.Tests
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class Base32Test
+    {
+        [Fact]
+        public void Base32Hex_InvalidStringInput()
+        {
+            Assert.Throws<ArgumentException>(() => Base32Hex.FromBase32HexString("XYZ"));
+            Assert.Throws<ArgumentException>(() => Base32Hex.FromBase32HexString("YZ"));
+            Assert.Throws<ArgumentException>(() => Base32Hex.FromBase32HexString("Z="));
+            Assert.Throws<ArgumentException>(() => Base32Hex.FromBase32HexString("11234^="));
+        }
+
+        [Fact]
+        public void Base32Hex_ValidConversion()
+        {
+            var expected = "CK0Q1GIN43N1ARRC9OSM6QPQR81H5M9A";
+            var expectedBytes = new byte[] { 101, 1, 160, 194, 87, 32, 238, 21, 111, 108, 78, 57, 99, 107, 58, 218, 3, 18, 217, 42 };
+            var bytes = Base32Hex.FromBase32HexString(expected);
+            var result = Base32Hex.ToBase32HexString(bytes);
+
+            Assert.Equal(expected, result);
+            Assert.Equal(expectedBytes, bytes);
+        }
+
+        [Fact]
+        public void Base32Hex_ValidConversion2()
+        {
+            var expected = "VVVVVVVV";
+            var expectedBytes = new byte[] { 255, 255, 255, 255, 255 };
+
+            var bytes = Base32Hex.FromBase32HexString(expected);
+            var result = Base32Hex.ToBase32HexString(bytes);
+
+            Assert.Equal(expected, result);
+            Assert.Equal(expectedBytes, bytes);
+        }
+    }
+}

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -612,7 +612,32 @@ namespace DnsClient.Tests
         }
 
         [Fact]
-        public void DnsRecord_TestBitmap()
+        public void DnsRecordFactory_NSec3ParamRecord()
+        {
+            var salt = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            var name = DnsString.Parse("example.com");
+
+            var writer = new DnsDatagramWriter();
+            writer.WriteByte(1); // Algorithm
+            writer.WriteByte(2); // Flags
+            writer.WriteUInt16NetworkOrder(100); // Iterations
+            writer.WriteByte((byte)salt.Length);
+            writer.WriteBytes(salt, salt.Length);
+
+            var factory = GetFactory(writer.Data);
+
+            var info = new ResourceRecordInfo(name, ResourceRecordType.NSEC3PARAM, QueryClass.IN, 0, writer.Data.Count);
+
+            var result = factory.GetRecord(info) as NSec3ParamRecord;
+
+            Assert.Equal(1, result.HashAlgorithm);
+            Assert.Equal(2, result.Flags);
+            Assert.Equal(100, result.Iterations);
+            Assert.Equal(salt, result.Salt);
+        }
+
+        [Fact]
+        public void DnsRecord_TestBitmap_MaxWindows()
         {
             var data = Enumerable.Repeat(0, ushort.MaxValue).Select((v, i) => (ushort)i).ToArray();
 

--- a/test/DnsClient.Tests/DnsResponseParsingTest.cs
+++ b/test/DnsClient.Tests/DnsResponseParsingTest.cs
@@ -41,6 +41,8 @@ namespace DnsClient.Tests
                 ResourceRecordType.NAPTR,
                 ResourceRecordType.TLSA,
                 ResourceRecordType.NSEC,
+                ResourceRecordType.NSEC3,
+                ResourceRecordType.NSEC3PARAM,
                 ResourceRecordType.SPF,
                 ResourceRecordType.DNSKEY,
                 ResourceRecordType.DS


### PR DESCRIPTION
Added
* NSEC3 resource record
* NSEC3PARAM resource record
* Base32 en-/de-coder with the hex version which is used by NSEC3
* Also fixed a few things in the bitmap reader implementation of the NSEC record and wrote a writer part, too, to test multi windowed bitmaps properly. The algorithm is inspired by the c++ implementation of the unbound resolver.