### PR TITLE
Observe canceled tasks in WithCancellation

### DIFF
--- a/src/DnsClient/TaskExtensions.cs
+++ b/src/DnsClient/TaskExtensions.cs
@@ -14,12 +14,11 @@
                     {
                         onCancel();
                     }
-                    catch
-                    {
-                        // observe the exception to avoid "System.AggregateException: A Task's exception(s) were
-                        // not observed either by Waiting on the Task or accessing its Exception property."
-                        task.ContinueWith(t => t.Exception);
-                    }
+                    catch { }
+                    
+                    // observe the exception to avoid "System.AggregateException: A Task's exception(s) were
+                    // not observed either by Waiting on the Task or accessing its Exception property."
+                    task.ContinueWith(t => t.Exception);
                     throw new OperationCanceledException(cancellationToken);
                 }
             }

--- a/src/DnsClient/TaskExtensions.cs
+++ b/src/DnsClient/TaskExtensions.cs
@@ -14,7 +14,12 @@
                     {
                         onCancel();
                     }
-                    catch { }
+                    catch
+                    {
+                        // observe the exception to avoid "System.AggregateException: A Task's exception(s) were
+                        // not observed either by Waiting on the Task or accessing its Exception property."
+                        task.ContinueWith(t => t.Exception);
+                    }
                     throw new OperationCanceledException(cancellationToken);
                 }
             }


### PR DESCRIPTION
After timeout, `WithCancellation` throws an exception meaning the `return await task.ConfigureAwait(false);` line is never invoked. If this task is faulted (likely after it was canceled) then it will not be observed and exceptions will be thrown on the finalizer thread.