### PR TITLE
Fixed some query cancellation implementation details

### DIFF
--- a/samples/MiniDig/RandomCommand.cs
+++ b/samples/MiniDig/RandomCommand.cs
@@ -73,7 +73,7 @@ namespace DigApp
             _runSync = SyncArg.HasValue();
 
             _settings = GetLookupSettings();
-            _settings.EnableAuditTrail = true;
+            _settings.EnableAuditTrail = false;
             _settings.ThrowDnsErrors = false;
             _settings.ContinueOnDnsError = false;
             _lookup = GetDnsLookup(_settings);

--- a/src/DnsClient/DnsMessageHandler.cs
+++ b/src/DnsClient/DnsMessageHandler.cs
@@ -23,7 +23,6 @@ namespace DnsClient
         public abstract Task<DnsResponseMessage> QueryAsync(
             IPEndPoint endpoint,
             DnsRequestMessage request,
-            Action<Action> cancelationCallback,
             CancellationToken cancellationToken);
 
         // Transient errors will be retried on the same NameServer before the resolver moves on

--- a/src/DnsClient/DnsUdpMessageHandler.cs
+++ b/src/DnsClient/DnsUdpMessageHandler.cs
@@ -128,7 +128,6 @@ namespace DnsClient
             }
             catch (SocketException se) when (se.SocketErrorCode == SocketError.OperationAborted)
             {
-                // we disposed it in case of a timeout request, lets indicate it actually timed out...
                 throw new TimeoutException();
             }
             catch (ObjectDisposedException)

--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -1110,16 +1110,11 @@ namespace DnsClient
                             using (cts)
                             using (linkedCts)
                             {
-                                Action onCancel = () => { };
                                 response = await handler.QueryAsync(
                                     serverInfo.IPEndPoint,
                                     request,
-                                    (cancel) =>
-                                    {
-                                        onCancel = cancel;
-                                    },
                                     (linkedCts ?? cts).Token)
-                                .WithCancellation(onCancel, (linkedCts ?? cts).Token)
+                                .WithCancellation((linkedCts ?? cts).Token)
                                 .ConfigureAwait(false);
                             }
                         }
@@ -1128,7 +1123,6 @@ namespace DnsClient
                             response = await handler.QueryAsync(
                                     serverInfo.IPEndPoint,
                                     request,
-                                    _ => { },
                                     cancellationToken)
                                 .ConfigureAwait(false);
                         }

--- a/src/DnsClient/TaskExtensions.cs
+++ b/src/DnsClient/TaskExtensions.cs
@@ -2,7 +2,7 @@
 {
     internal static class TaskExtensions
     {
-        public static async Task<T> WithCancellation<T>(this Task<T> task, Action onCancel, CancellationToken cancellationToken)
+        public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
         {
             var tcs = new TaskCompletionSource<bool>();
 
@@ -10,12 +10,6 @@
             {
                 if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                 {
-                    try
-                    {
-                        onCancel();
-                    }
-                    catch { }
-
                     // observe the exception to avoid "System.AggregateException: A Task's exception(s) were
                     // not observed either by Waiting on the Task or accessing its Exception property."
                     _ = task.ContinueWith(t => t.Exception);

--- a/src/DnsClient/TaskExtensions.cs
+++ b/src/DnsClient/TaskExtensions.cs
@@ -15,6 +15,10 @@
                         onCancel();
                     }
                     catch { }
+
+                    // observe the exception to avoid "System.AggregateException: A Task's exception(s) were
+                    // not observed either by Waiting on the Task or accessing its Exception property."
+                    _ = task.ContinueWith(t => t.Exception);
                     throw new OperationCanceledException(cancellationToken);
                 }
             }

--- a/test-other/Benchmarks/DnsClientBenchmarks.DatagramReader.cs
+++ b/test-other/Benchmarks/DnsClientBenchmarks.DatagramReader.cs
@@ -138,7 +138,6 @@ namespace Benchmarks
                 public override Task<DnsResponseMessage> QueryAsync(
                     IPEndPoint server,
                     DnsRequestMessage request,
-                    Action<Action> cancelationCallback,
                     CancellationToken cancellationToken)
                 {
                     // no need to run async here as we don't do any IO

--- a/test-other/Benchmarks/DnsClientBenchmarks.RequestResponseParsing.cs
+++ b/test-other/Benchmarks/DnsClientBenchmarks.RequestResponseParsing.cs
@@ -166,7 +166,6 @@ namespace Benchmarks
         public override Task<DnsResponseMessage> QueryAsync(
             IPEndPoint server,
             DnsRequestMessage request,
-            Action<Action> cancelationCallback,
             CancellationToken cancellationToken)
         {
             return Task.FromResult(Query(server, request, Timeout.InfiniteTimeSpan));

--- a/test/DnsClient.Tests/DnsClient.Tests.csproj
+++ b/test/DnsClient.Tests/DnsClient.Tests.csproj
@@ -9,6 +9,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>DnsClient.Tests</PackageId>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/DnsClient.Tests/DnsResponseParsingTest.cs
+++ b/test/DnsClient.Tests/DnsResponseParsingTest.cs
@@ -359,7 +359,6 @@ namespace DnsClient.Tests
             public override Task<DnsResponseMessage> QueryAsync(
                 IPEndPoint server,
                 DnsRequestMessage request,
-                Action<Action> cancelationCallback,
                 CancellationToken cancellationToken)
             {
                 // no need to run async here as we don't do any IO

--- a/test/DnsClient.Tests/LookupClientRetryTest.cs
+++ b/test/DnsClient.Tests/LookupClientRetryTest.cs
@@ -1664,7 +1664,7 @@ namespace DnsClient.Tests
             return _onQuery(endpoint, request);
         }
 
-        public override Task<DnsResponseMessage> QueryAsync(IPEndPoint endpoint, DnsRequestMessage request, Action<Action> cancelationCallback, CancellationToken cancellationToken)
+        public override Task<DnsResponseMessage> QueryAsync(IPEndPoint endpoint, DnsRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(_onQuery(endpoint, request));
         }

--- a/test/DnsClient.Tests/LookupConfigurationTest.cs
+++ b/test/DnsClient.Tests/LookupConfigurationTest.cs
@@ -1039,7 +1039,6 @@ namespace DnsClient.Tests
             public override Task<DnsResponseMessage> QueryAsync(
                 IPEndPoint server,
                 DnsRequestMessage request,
-                Action<Action> cancelationCallback,
                 CancellationToken cancellationToken)
             {
                 LastServer = server;


### PR DESCRIPTION
Fixed one bug where the wrong cancellation token was passed to the async query impl...
Removed the custom cancellation callback to dispose UdpClient for example, can now use the cancellation token + a callback registration.

Includes other fix from #121