### PR TITLE
Allow max recursion on datagram reader

### DIFF
--- a/test/DnsClient.Tests/DatagramReaderTest.cs
+++ b/test/DnsClient.Tests/DatagramReaderTest.cs
@@ -54,9 +54,22 @@ namespace DnsClient.Tests
             var bytes = new byte[] { 5, 90, 90, 92, 46, 90, 2, 56, 56, 0 };
 
             var reader = new DnsDatagramReader(new ArraySegment<byte>(bytes));
-
-            var labels = reader.ReadLabels();
+            var recursion = 0;
+            var labels = reader.ReadLabels(ref recursion);
             Assert.Equal(2, labels.Count);
+        }
+
+        [Fact]
+        public void DatagramReader_Labels_FromBytesRecursionMax()
+        {
+            var bytes = new byte[] { 5, 90, 90, 92, 46, 90, 2, 56, 56, 0 };
+
+            var reader = new DnsDatagramReader(new ArraySegment<byte>(bytes), maxRecursion: 1);
+            Assert.Throws<DnsResponseParseException>(() =>
+            {
+                var recursion = 0;
+                var _ = reader.ReadLabels(ref recursion);
+            });
         }
 
         [Fact]


### PR DESCRIPTION
Added a unit test too. The datagram reader has an optional max recursion param that defaults to 1000.