### PR TITLE
Update target frameworks for .NET 6, .NET Framework 4.7.1, .NET Standard 2.0, .NET Standard 2.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -173,9 +173,6 @@ dotnet_diagnostic.CS1591.severity = warning
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = warning
 
-# CA1825: Avoid zero-length array allocations (TODO: until we drop .NET45)
-dotnet_diagnostic.CA1825.severity = silent
-
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' - (TODO: more improvements needed)
 dotnet_diagnostic.CA1835.severity = silent
 

--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -44,9 +44,17 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" Condition=" '$(TargetFramework)' != 'net6.0' " />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
+
+   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+   </ItemGroup>
+
+   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+   </ItemGroup>
 
 </Project>

--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -3,7 +3,7 @@
     <VersionPrefix>1.7.0</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
 
-    <TargetFrameworks>net6.0;net5.0;netstandard1.3;netstandard2.0;netstandard2.1;net45;net471</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net471</TargetFrameworks>
     <DebugType>full</DebugType>
 
     <Product>DnsClient.NET</Product>
@@ -44,27 +44,9 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" Condition=" '$(TargetFramework)' != 'net6.0' " />
   </ItemGroup>
 
 </Project>

--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -48,13 +48,13 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
-   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-   </ItemGroup>
+  </ItemGroup>
 
-   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-   </ItemGroup>
+  </ItemGroup>
 
 </Project>

--- a/src/DnsClient/DnsTcpMessageHandler.cs
+++ b/src/DnsClient/DnsTcpMessageHandler.cs
@@ -286,11 +286,7 @@ namespace DnsClient
                 {
                     try
                     {
-#if !NET45
                         Client.Dispose();
-#else
-                        Client.Close();
-#endif
                     }
                     catch { }
                 }

--- a/src/DnsClient/DnsUdpMessageHandler.cs
+++ b/src/DnsClient/DnsUdpMessageHandler.cs
@@ -55,11 +55,7 @@ namespace DnsClient
             {
                 try
                 {
-#if !NET45
                     udpClient.Dispose();
-#else
-                    udpClient.Close();
-#endif
                 }
                 catch { }
             }
@@ -78,11 +74,7 @@ namespace DnsClient
             {
                 using var callback = cancellationToken.Register(() =>
                 {
-#if !NET45
                     udpClient.Dispose();
-#else
-                    udpClient.Close();
-#endif
                 });
 
                 using (var writer = new DnsDatagramWriter())
@@ -103,15 +95,10 @@ namespace DnsClient
                         cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     var response = GetResponseMessage(new ArraySegment<byte>(memory.Buffer, 0, received));
-#elif !NET45
+#else
                     int received = await udpClient.Client.ReceiveAsync(new ArraySegment<byte>(memory.Buffer), SocketFlags.None).ConfigureAwait(false);
 
                     var response = GetResponseMessage(new ArraySegment<byte>(memory.Buffer, 0, received));
-
-#else
-                    var result = await udpClient.ReceiveAsync().ConfigureAwait(false);
-
-                    var response = GetResponseMessage(new ArraySegment<byte>(result.Buffer, 0, result.Buffer.Length));
 #endif
 
                     ValidateResponse(request, response);
@@ -132,11 +119,7 @@ namespace DnsClient
             {
                 try
                 {
-#if !NET45
                     udpClient.Dispose();
-#else
-                    udpClient.Close();
-#endif
                 }
                 catch { }
             }

--- a/src/DnsClient/Interop/Windows/NameResolutionPolicy.cs
+++ b/src/DnsClient/Interop/Windows/NameResolutionPolicy.cs
@@ -8,8 +8,6 @@ using Microsoft.Win32;
 
 namespace DnsClient.Windows
 {
-#if !NET45
-
     internal static class NameResolutionPolicy
     {
         private static readonly char[] s_splitOn = new char[] { ';' };
@@ -129,5 +127,4 @@ namespace DnsClient.Windows
             }
         }
     }
-#endif
 }

--- a/src/DnsClient/NameServer.cs
+++ b/src/DnsClient/NameServer.cs
@@ -241,8 +241,7 @@ namespace DnsClient
         /// </returns>
         public static IReadOnlyCollection<NameServer> ResolveNameServers(bool skipIPv6SiteLocal = true, bool fallbackToGooglePublicDns = true)
         {
-            // TODO: Use Array.Empty after dropping NET45
-            IReadOnlyCollection<NameServer> nameServers = new NameServer[0];
+            IReadOnlyCollection<NameServer> nameServers = Array.Empty<NameServer>();
 
             var exceptions = new List<Exception>();
 
@@ -259,7 +258,6 @@ namespace DnsClient
                 exceptions.Add(ex);
             }
 
-#if !NET45
             if (exceptions.Count > 0)
             {
                 logger?.LogDebug("Using native path to resolve servers.");
@@ -305,7 +303,6 @@ namespace DnsClient
                 logger?.LogInformation(ex, "Resolving name servers from NRPT failed.");
             }
 
-#endif
             IReadOnlyCollection<NameServer> filtered = nameServers
                 .Where(p => (p.IPEndPoint.Address.AddressFamily == AddressFamily.InterNetwork
                             || p.IPEndPoint.Address.AddressFamily == AddressFamily.InterNetworkV6)
@@ -344,8 +341,6 @@ namespace DnsClient
             logger?.LogDebug("Resolved {0} name servers: [{1}].", filtered.Count, string.Join(",", filtered.AsEnumerable()));
             return filtered;
         }
-
-#if !NET45
 
         /// <summary>
         /// Using my custom native implementation to support UWP apps and such until <see cref="NetworkInterface.GetAllNetworkInterfaces"/>
@@ -405,8 +400,6 @@ namespace DnsClient
         {
             return NameResolutionPolicy.Resolve();
         }
-
-#endif
 
         internal static IReadOnlyCollection<NameServer> ValidateNameServers(IReadOnlyCollection<NameServer> servers, ILogger logger = null)
         {

--- a/src/DnsClient/Protocol/RRSigRecord.cs
+++ b/src/DnsClient/Protocol/RRSigRecord.cs
@@ -149,8 +149,8 @@ namespace DnsClient.Protocol
             Algorithm = (DnsSecurityAlgorithm)algorithm;
             Labels = labels;
             OriginalTtl = originalTtl;
-            SignatureExpiration = FromUnixTimeSeconds(signatureExpiration);
-            SignatureInception = FromUnixTimeSeconds(signatureInception);
+            SignatureExpiration = DateTimeOffset.FromUnixTimeSeconds(signatureExpiration);
+            SignatureInception = DateTimeOffset.FromUnixTimeSeconds(signatureInception);
             KeyTag = keyTag;
             SignersName = signersName ?? throw new ArgumentNullException(nameof(signersName));
             Signature = signature ?? throw new ArgumentNullException(nameof(signature));
@@ -170,13 +170,6 @@ namespace DnsClient.Protocol
                 KeyTag,
                 SignersName,
                 SignatureAsString);
-        }
-
-        // DateTimeOffset does have that method build in .NET47+ but not .NET45 which we will support. TODO: delete this when we drop support for .NET 4.5
-        private static DateTimeOffset FromUnixTimeSeconds(long seconds)
-        {
-            long ticks = seconds * TimeSpan.TicksPerSecond + new DateTime(1970, 1, 1, 0, 0, 0).Ticks;
-            return new DateTimeOffset(ticks, TimeSpan.Zero);
         }
     }
 }

--- a/test-other/DnsClient.TestsCommon/DnsClient.TestsCommon.csproj
+++ b/test-other/DnsClient.TestsCommon/DnsClient.TestsCommon.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DnsClient\DnsClient.csproj" />

--- a/test-other/OldReference/OldReference.csproj
+++ b/test-other/OldReference/OldReference.csproj
@@ -1,22 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks><!--net45-->;net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net471;net6.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-
-  <ItemGroup>
-  </ItemGroup>
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="DnsClient" Version="1.1.0" />
-  </ItemGroup>-->
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <PackageReference Include="DnsClient" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="DnsClient" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/test/DnsClient.Tests/DnsClient.Tests.csproj
+++ b/test/DnsClient.Tests/DnsClient.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net471;netcoreapp3.1;net6.0;
-    </TargetFrameworks>
+    <TargetFrameworks>net6.0;net471</TargetFrameworks>
     <AssemblyName>DnsClient.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DnsClient.Tests/UdpServer.cs
+++ b/test/DnsClient.Tests/UdpServer.cs
@@ -63,12 +63,7 @@ namespace DnsClient.Tests
 
         public void Dispose()
         {
-#if !NET45
             _client.Dispose();
-#else
-            _client.Close();
-#endif
-
             _disposed = true;
         }
     }

--- a/test/DnsClient.ThirdParty.Tests/DnsClient.ThirdParty.Tests.csproj
+++ b/test/DnsClient.ThirdParty.Tests/DnsClient.ThirdParty.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net471;netcoreapp3.1;net6.0
-    </TargetFrameworks>
+    <TargetFrameworks>net6.0;net471</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -28,10 +26,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="MongoDB.Driver" Version="2.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">


### PR DESCRIPTION
 What's changed?
- Target frameworks now: .NET 6, .NET Framework 4.7.1, .NET Standard 2.0, .NET Standard 2.1

**Why target frameworks were changed?**

Microsoft recommend to target .NET 6, .NET Standard and minimal supported .NET Framework
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/older-framework-versions-dropped

Notes:
.NET Framework 4.5 is out of support, .NET Framework 4.6.2 is the older version that is still supported
https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/

.NET 5 is out of support
https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/

.NET Core 3.1 is out of support
https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/
