### PR TITLE
Add CERT resource record support

### DIFF
--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -135,6 +135,10 @@ namespace DnsClient
                     result = ResolveNaptrRecord(info);
                     break;
 
+                case ResourceRecordType.CERT: // 37
+                    result = ResolveCertRecord(info);
+                    break;
+
                 case ResourceRecordType.OPT: // 41
                     result = ResolveOptRecord(info);
                     break;
@@ -263,6 +267,17 @@ namespace DnsClient
             var replacement = _reader.ReadDnsName();
 
             return new NAPtrRecord(info, order, preference, flags, services, regexp, replacement);
+        }
+
+        private DnsResourceRecord ResolveCertRecord(ResourceRecordInfo info)
+        {
+            var startIndex = _reader.Index;
+            var certType = _reader.ReadUInt16NetworkOrder();
+            var keyTag = _reader.ReadUInt16NetworkOrder();
+            var algorithm = _reader.ReadByte();
+            var publicKey = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
+
+            return new CertRecord(info, certType, keyTag, algorithm, publicKey);
         }
 
         private DnsResourceRecord ResolveOptRecord(ResourceRecordInfo info)

--- a/src/DnsClient/Protocol/CertRecord.cs
+++ b/src/DnsClient/Protocol/CertRecord.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
+using System.Text;
 
 namespace DnsClient.Protocol;
 
@@ -53,9 +53,9 @@ public class CertRecord : DnsResourceRecord
     public IReadOnlyList<byte> PublicKey { get; }
 
     /// <summary>
-    /// Get an X509 Certificate instance from the record
+    /// Gets the base64 string representation of the <see cref="PublicKey"/>.
     /// </summary>
-    public X509Certificate2 Certificate { get; }
+    public string PublicKeyAsString { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DnsKeyRecord"/> class
@@ -73,14 +73,12 @@ public class CertRecord : DnsResourceRecord
         KeyTag = keyTag;
         Algorithm = (DnsSecurityAlgorithm)algorithm;
         PublicKey = publicKey ?? throw new ArgumentNullException(nameof(publicKey));
-        Certificate = new X509Certificate2(publicKey);
+        PublicKeyAsString = Convert.ToBase64String(publicKey);
     }
 
-    /// <summary>
-    /// Returns a string representation of the record's value only.
-    /// <see cref="ToString(int)"/> uses this to compose the full string value of this instance.
-    /// </summary>
-    /// <returns>A string representing this record.</returns>
-    private protected override string RecordToString() => throw new NotImplementedException();
-
+    
+    private protected override string RecordToString()
+    {
+        return string.Format("{0} {1} {2} {3}", (int)CertType, KeyTag, (int)Algorithm, PublicKeyAsString);
+    }
 }

--- a/src/DnsClient/Protocol/CertRecord.cs
+++ b/src/DnsClient/Protocol/CertRecord.cs
@@ -79,6 +79,6 @@ public class CertRecord : DnsResourceRecord
     
     private protected override string RecordToString()
     {
-        return string.Format("{0} {1} {2} {3}", (int)CertType, KeyTag, (int)Algorithm, PublicKeyAsString);
+        return string.Format("{0} {1} {2} {3}", CertType, KeyTag, Algorithm, PublicKeyAsString);
     }
 }

--- a/src/DnsClient/Protocol/CertRecord.cs
+++ b/src/DnsClient/Protocol/CertRecord.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+
+namespace DnsClient.Protocol;
+
+
+/// <summary>A representation of CERT RDATA format.
+/// <remarks>
+/// RFC 4398.
+///
+/// Record format:
+/// <code>
+///                     1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+/// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |             type              |             key tag           |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |   algorithm   |                                               /
+/// +---------------+            certificate or CRL                 /
+/// /                                                               /
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+/// </code>
+/// </remarks>
+/// <see cref="https://datatracker.ietf.org/doc/html/rfc4398#section-2"/>
+/// </summary>
+public class CertRecord : DnsResourceRecord
+{
+    /// <summary>
+    /// Gets the <see cref="CertType"/> referred to by this record
+    /// </summary>
+    /// <value>The CERT RR type of this certificate</value>
+    public CertificateType CertType { get; }
+
+    /// <summary>
+    /// Gets the key tag value of the <see cref="DnsKeyRecord"/> referred to by this record.
+    /// </summary>
+    /// <seealso href="https://tools.ietf.org/html/rfc4034#appendix-B">Key Tag Calculation</seealso>
+    public int KeyTag { get; }
+
+    /// <summary>
+    /// Gets certificate algorithm (see RFC 4034, Appendix 1)
+    /// </summary>
+    public DnsSecurityAlgorithm Algorithm { get; }
+
+    /// <summary>
+    /// Gets the raw certificate RDATA.
+    /// </summary>
+    /// <summary>
+    /// Gets the public key material.
+    /// The format depends on the <see cref="Algorithm"/> of the key being stored.
+    /// </summary>
+    public IReadOnlyList<byte> PublicKey { get; }
+
+    /// <summary>
+    /// Get an X509 Certificate instance from the record
+    /// </summary>
+    public X509Certificate2 Certificate { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DnsKeyRecord"/> class
+    /// </summary>
+    /// <param name="info"></param>
+    /// <param name="flags"></param>
+    /// <param name="protocol"></param>
+    /// <param name="algorithm"></param>
+    /// <param name="publicKey"></param>
+    /// <exception cref="ArgumentNullException">If <paramref name="info"/> or <paramref name="publicKey"/> is null.</exception>
+    public CertRecord(ResourceRecordInfo info, int certType, int keyTag, byte algorithm, byte[] publicKey)
+        : base(info)
+    {
+        CertType = (CertificateType)certType;
+        KeyTag = keyTag;
+        Algorithm = (DnsSecurityAlgorithm)algorithm;
+        PublicKey = publicKey ?? throw new ArgumentNullException(nameof(publicKey));
+        Certificate = new X509Certificate2(publicKey);
+    }
+
+    /// <summary>
+    /// Returns a string representation of the record's value only.
+    /// <see cref="ToString(int)"/> uses this to compose the full string value of this instance.
+    /// </summary>
+    /// <returns>A string representing this record.</returns>
+    private protected override string RecordToString() => throw new NotImplementedException();
+
+}

--- a/src/DnsClient/Protocol/CertificateType.cs
+++ b/src/DnsClient/Protocol/CertificateType.cs
@@ -1,0 +1,47 @@
+﻿namespace DnsClient.Protocol;
+
+/// <summary>
+/// Certificate type values
+/// </summary>
+/// <remarks>
+///  <seealso href="https://tools.ietf.org/html/rfc4398#section-2.1">RFC 4398 section 2.1</seealso>
+/// </remarks>
+public enum CertificateType
+{
+    /// <summary>
+    /// Reserved certificate type.
+    /// </summary>
+    Reserved = 0,
+    /// <summary>
+    /// X509 certificate
+    /// </summary>
+    X509 = 1,
+    /// <summary>
+    /// SPKI certificate
+    /// </summary>
+    SPKI,
+    /// <summary>
+    /// OpenPGP certificate
+    /// </summary>
+    PGP,        // Open PGP
+    /// <summary>
+    /// URL to an X.509 data object 
+    /// </summary>
+    IPKIX,
+    /// <summary>
+    ///  Url of an SPKI certificate
+    /// </summary>
+    ISPKI,
+    /// <summary>
+    /// fingerprint + URL of an OpenPGP packet
+    /// </summary>
+    IPGP,
+    /// <summary>
+    /// Attribute Certificate
+    /// </summary>
+    ACPKIX,
+    /// <summary>
+    /// The URL of an Attribute Certificate
+    /// </summary>
+    IACPKIK
+}

--- a/src/DnsClient/Protocol/CertificateType.cs
+++ b/src/DnsClient/Protocol/CertificateType.cs
@@ -13,17 +13,17 @@ public enum CertificateType
     /// </summary>
     Reserved = 0,
     /// <summary>
-    /// X509 certificate
+    /// X.509 as per PKIX
     /// </summary>
-    X509 = 1,
+    PKIX = 1,
     /// <summary>
     /// SPKI certificate
     /// </summary>
     SPKI,
     /// <summary>
-    /// OpenPGP certificate
+    /// OpenPGP packet
     /// </summary>
-    PGP,        // Open PGP
+    PGP,
     /// <summary>
     /// URL to an X.509 data object 
     /// </summary>
@@ -43,5 +43,13 @@ public enum CertificateType
     /// <summary>
     /// The URL of an Attribute Certificate
     /// </summary>
-    IACPKIK
+    IACPKIK,
+    /// <summary>
+    /// URI private
+    /// </summary>
+    URI = 253,
+    /// <summary>
+    /// OID private
+    /// </summary>
+    OID = 254
 }

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -169,6 +169,16 @@ namespace DnsClient.Protocol
         NAPTR = 35,
 
         /// <summary>
+        /// Cryptographic public keys are frequently published, and their
+        /// authenticity is demonstrated by certificates.  A CERT resource record
+        /// (RR) is defined so that such certificates and related certificate
+        /// revocation lists can be stored in the Domain Name System (DNS).
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc4398">RFC 4398</seealso>
+        /// <seealso cref="CertRecord"/>
+        CERT = 37,
+
+        /// <summary>
         /// Option record.
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc6891">RFC 6891</seealso>

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -166,6 +166,16 @@ namespace DnsClient
         NAPTR = ResourceRecordType.NAPTR,
 
         /// <summary>
+        /// Cryptographic public keys are frequently published, and their
+        /// authenticity is demonstrated by certificates.  A CERT resource record
+        /// (RR) is defined so that such certificates and related certificate
+        /// revocation lists can be stored in the Domain Name System (DNS).
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc4398">RFC 4398</seealso>
+        /// <seealso cref="CertRecord"/>
+        CERT = ResourceRecordType.CERT,
+
+        /// <summary>
         /// DS rfc4034
         /// </summary>
         /// <seealso href="https://tools.ietf.org/html/rfc4034#section-5.1">RFC 4034</seealso>

--- a/src/DnsClient/ResourceRecordCollectionExtensions.cs
+++ b/src/DnsClient/ResourceRecordCollectionExtensions.cs
@@ -206,6 +206,17 @@ namespace System.Linq
         }
 
         /// <summary>
+        /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="CertRecord"/>s only.
+        /// </summary>
+        /// <param name="records">The records.</param>
+        /// <returns>The list of <see cref="CertRecord"/>.</returns>
+        public static IEnumerable<CertRecord> CertRecords(this IEnumerable<DnsResourceRecord> records)
+        {
+            return records.OfType<CertRecord>();
+        }
+
+
+        /// <summary>
         /// Filters the elements of an <see cref="IEnumerable{T}"/> to return <see cref="UriRecord"/>s only.
         /// </summary>
         /// <param name="records">The records.</param>

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using DnsClient.Internal;
 using DnsClient.Protocol;
@@ -14,16 +15,9 @@ namespace DnsClient.Tests
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class DnsRecordFactoryTest
     {
-        private readonly ITestOutputHelper _testOutputHelper;
-
         static DnsRecordFactoryTest()
         {
             Tracing.Source.Switch.Level = System.Diagnostics.SourceLevels.All;
-        }
-
-        public DnsRecordFactoryTest(ITestOutputHelper testOutputHelper)
-        {
-            _testOutputHelper = testOutputHelper;
         }
 
         internal DnsRecordFactory GetFactory(byte[] data)
@@ -360,7 +354,7 @@ H+L10KwE7wqqmkxwfib5kwgNyrlXtx0=
             Assert.Equal(DnsSecurityAlgorithm.RSASHA256, result.Algorithm);
             Assert.Equal(expectedBytes, result.PublicKey);
 
-            var cert = result.Certificate;
+            var cert = new X509Certificate2(Convert.FromBase64String(result.PublicKeyAsString));
             Assert.Equal("sha256RSA", cert.SignatureAlgorithm.FriendlyName);
             Assert.Equal("CN=D1_valA, E=d1@domain1.dcdt31.healthit.gov", cert.Subject);
 

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -2,19 +2,28 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using System.Text;
 using DnsClient.Internal;
 using DnsClient.Protocol;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DnsClient.Tests
 {
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class DnsRecordFactoryTest
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
         static DnsRecordFactoryTest()
         {
             Tracing.Source.Switch.Level = System.Diagnostics.SourceLevels.All;
+        }
+
+        public DnsRecordFactoryTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
         }
 
         internal DnsRecordFactory GetFactory(byte[] data)
@@ -299,6 +308,66 @@ namespace DnsClient.Tests
             Assert.Equal(NAPtrRecord.SFlag.ToString(), result.Flags);
             Assert.Equal(NAPtrRecord.ServiceKeySipUdp, result.Services);
             Assert.Equal("", result.RegularExpression);
+        }
+
+        [Fact]
+        public void DnsRecordFactory_CertRecord()
+        {
+            var expectedPublicKey = @"-----BEGIN CERTIFICATE-----
+MIIEMzCCAxugAwIBAgIBAzANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtkY2R0
+MzEuaGVhbHRoaXQuZ292X2NhX3Jvb3QwHhcNMjIwMjA0MTUzNzUxWhcNMzIwMjA1
+MDE0OTUxWjBBMS0wKwYJKoZIhvcNAQkBFh5kMUBkb21haW4xLmRjZHQzMS5oZWFs
+dGhpdC5nb3YxEDAOBgNVBAMMB0QxX3ZhbEEwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQDHPWJogAq6zCU1zU6ar4GAvRb6bjCTSzm19E98E3dCCG8ZSgWH
+yZh3w6M/btu7qMDStrpzMGD1H5TiqS/mEFNNcJP2r8C6T8RKV2xEqhsJlwOoguzJ
+4MyePoVYG84/gm5v03BCp91uoz4O1WFrppu439njipv8wUwsvf6ukidhAgP9mEoN
+w1sCB1U9zOtpPmbRczMrYyDBWqFaxiaDD9xYaYqal7Ph7adKohBDZA1P7H/Jkxdf
+uCwULVDn+bcHD3eW9NToeZ7gc0CV75kVnI/7WbJ6mfx72zOIzEm1AFed36yuEpal
+VjCzhJO4ZmmfJxfXr36UICKHQIM/xwSEXqJtAgMBAAGjggFPMIIBSzAfBgNVHSME
+GDAWgBSIM9vz74ArTwMFMk3q5ShNOYQhMjApBgNVHQ4EIgQg1WLu98WJoAtR1X7K
+ZiHWfIcONgrBBtzuLgNWkQklJugwCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCBaAw
+KQYDVR0RBCIwIIEeZDFAZG9tYWluMS5kY2R0MzEuaGVhbHRoaXQuZ292MFUGA1Ud
+HwROMEwwSqBIoEaGRGh0dHA6Ly9wa2kuZGNkdDMxLmhlYWx0aGl0LmdvdjoxMDA4
+MC9kY2R0MzEuaGVhbHRoaXQuZ292X2NhX3Jvb3QuY3JsMGAGCCsGAQUFBwEBBFQw
+UjBQBggrBgEFBQcwAoZEaHR0cDovL3BraS5kY2R0MzEuaGVhbHRoaXQuZ292OjEw
+MDgwL2RjZHQzMS5oZWFsdGhpdC5nb3ZfY2Ffcm9vdC5jZXIwDQYJKoZIhvcNAQEL
+BQADggEBAGqMC2kEA6acNgmUueCbPuLj7uePRGaRk6x0rSEY6mTGoBXci+s9EXbx
+a7d/glNFNgQC9KP35esriqSfUn2bsDmtlTs+A79+ldMRH5SWvEmI5f7s9SitLIYR
+uRBLE693R7/1DjyUrEFxpdL16O8Y2kIKO9S8lrscNBOg7hW0RKYb4VBnlsNw3jk2
+rXyGcFZ63D8VsdgUJTh2BKhpiY37gd/+ILUcylpmC5Uf3yWM2wYRMS6IVACllv+U
+PoPWSE2fsrMpfCtDFeUL71gn8g6TYIctVHTn4OeuhHQ6Yt21rgQnlpDFVt0p9sGl
+H+L10KwE7wqqmkxwfib5kwgNyrlXtx0=
+-----END CERTIFICATE-----";
+
+            var expectedBytes = Encoding.UTF8.GetBytes(expectedPublicKey);
+            var name = DnsString.Parse("example.com");
+            using var memory = new PooledBytes(expectedBytes.Length);
+
+            var writer = new DnsDatagramWriter(new ArraySegment<byte>(memory.Buffer));
+            writer.WriteInt16NetworkOrder((short)CertificateType.X509); // 2
+            writer.WriteInt16NetworkOrder((short)27891); // 2
+            writer.WriteByte((byte)DnsSecurityAlgorithm.RSASHA256);  // 1
+            writer.WriteBytes(expectedBytes, expectedBytes.Length);
+
+            var factory = GetFactory(writer.Data);
+
+            var info = new ResourceRecordInfo(name, ResourceRecordType.CERT, QueryClass.IN, 0, writer.Data.Count);
+
+            var result = factory.GetRecord(info) as CertRecord;
+            Assert.NotNull(result);
+            Assert.Equal(27891, result.KeyTag);
+            Assert.Equal(CertificateType.X509, result.CertType);
+            Assert.Equal(DnsSecurityAlgorithm.RSASHA256, result.Algorithm);
+            Assert.Equal(expectedBytes, result.PublicKey);
+
+            var cert = result.Certificate;
+            Assert.Equal("sha256RSA", cert.SignatureAlgorithm.FriendlyName);
+            Assert.Equal("CN=D1_valA, E=d1@domain1.dcdt31.healthit.gov", cert.Subject);
+
+            var x509Extension = cert.Extensions["2.5.29.17"];
+            Assert.NotNull(x509Extension);
+            var asnData = new AsnEncodedData(x509Extension.Oid, x509Extension.RawData);
+            Assert.Equal("RFC822 Name=d1@domain1.dcdt31.healthit.gov", asnData.Format(false));
         }
 
         [Fact]

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -338,9 +338,9 @@ H+L10KwE7wqqmkxwfib5kwgNyrlXtx0=
             using var memory = new PooledBytes(expectedBytes.Length);
 
             var writer = new DnsDatagramWriter(new ArraySegment<byte>(memory.Buffer));
-            writer.WriteInt16NetworkOrder((short)CertificateType.X509); // 2
-            writer.WriteInt16NetworkOrder((short)27891); // 2
-            writer.WriteByte((byte)DnsSecurityAlgorithm.RSASHA256);  // 1
+            writer.WriteInt16NetworkOrder((short)CertificateType.PKIX); // 2 bytes
+            writer.WriteInt16NetworkOrder((short)27891); // 2 bytes
+            writer.WriteByte((byte)DnsSecurityAlgorithm.RSASHA256);  // 1 byte
             writer.WriteBytes(expectedBytes, expectedBytes.Length);
 
             var factory = GetFactory(writer.Data);
@@ -350,7 +350,7 @@ H+L10KwE7wqqmkxwfib5kwgNyrlXtx0=
             var result = factory.GetRecord(info) as CertRecord;
             Assert.NotNull(result);
             Assert.Equal(27891, result.KeyTag);
-            Assert.Equal(CertificateType.X509, result.CertType);
+            Assert.Equal(CertificateType.PKIX, result.CertType);
             Assert.Equal(DnsSecurityAlgorithm.RSASHA256, result.Algorithm);
             Assert.Equal(expectedBytes, result.PublicKey);
 

--- a/test/DnsClient.Tests/DnsResponseParsingTest.cs
+++ b/test/DnsClient.Tests/DnsResponseParsingTest.cs
@@ -45,7 +45,8 @@ namespace DnsClient.Tests
                 ResourceRecordType.NSEC3PARAM,
                 ResourceRecordType.SPF,
                 ResourceRecordType.DNSKEY,
-                ResourceRecordType.DS
+                ResourceRecordType.DS,
+                ResourceRecordType.CERT
             };
 
             foreach (var t in types)

--- a/test/DnsClient.Tests/LookupTest.cs
+++ b/test/DnsClient.Tests/LookupTest.cs
@@ -828,7 +828,7 @@ namespace DnsClient.Tests
             var certRecord = result.Answers.CertRecords().First();
             Assert.NotNull(certRecord);
             Assert.Equal("d1.domain1.dcdt31.healthit.gov.", certRecord.DomainName);
-            Assert.Equal(CertificateType.X509, certRecord.CertType);
+            Assert.Equal(CertificateType.PKIX, certRecord.CertType);
 
             var cert = new X509Certificate2(Convert.FromBase64String(certRecord.PublicKeyAsString));
             Assert.Equal("sha256RSA", cert.SignatureAlgorithm.FriendlyName);

--- a/test/DnsClient.Tests/LookupTest.cs
+++ b/test/DnsClient.Tests/LookupTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using DnsClient.Protocol;
@@ -778,7 +779,7 @@ namespace DnsClient.Tests
             Assert.Equal("d1.domain1.dcdt31.healthit.gov.", certRecord.DomainName);
             Assert.Equal(CertificateType.X509, certRecord.CertType);
 
-            var cert = certRecord.Certificate;
+            var cert = new X509Certificate2(Convert.FromBase64String(certRecord.PublicKeyAsString));
             Assert.Equal("sha256RSA", cert.SignatureAlgorithm.FriendlyName);
             Assert.Equal("CN=D1_valA, E=d1@domain1.dcdt31.healthit.gov", cert.Subject);
 
@@ -786,6 +787,7 @@ namespace DnsClient.Tests
             Assert.NotNull(x509Extension);
             var asnData = new AsnEncodedData(x509Extension.Oid, x509Extension.RawData);
             Assert.Equal("RFC822 Name=d1@domain1.dcdt31.healthit.gov", asnData.Format(false));
+            
         }
 
         [Fact]

--- a/test/DnsClient.Tests/LookupTest.cs
+++ b/test/DnsClient.Tests/LookupTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using DnsClient.Protocol;
@@ -765,6 +766,27 @@ namespace DnsClient.Tests
             Assert.NotNull(host.HostName);
         }
 
+        [Fact]
+        public async Task Lookup_Query_CERT()
+        {
+            var client = new LookupClient(NameServer.Cloudflare);
+            var result = await client.QueryAsync("d1.domain1.dcdt31.healthit.gov", QueryType.CERT).ConfigureAwait(false);
+
+            Assert.NotEmpty(result.Answers.CertRecords());
+            var certRecord = result.Answers.CertRecords().First();
+            Assert.NotNull(certRecord);
+            Assert.Equal("d1.domain1.dcdt31.healthit.gov.", certRecord.DomainName);
+            Assert.Equal(CertificateType.X509, certRecord.CertType);
+
+            var cert = certRecord.Certificate;
+            Assert.Equal("sha256RSA", cert.SignatureAlgorithm.FriendlyName);
+            Assert.Equal("CN=D1_valA, E=d1@domain1.dcdt31.healthit.gov", cert.Subject);
+
+            var x509Extension = cert.Extensions["2.5.29.17"];
+            Assert.NotNull(x509Extension);
+            var asnData = new AsnEncodedData(x509Extension.Oid, x509Extension.RawData);
+            Assert.Equal("RFC822 Name=d1@domain1.dcdt31.healthit.gov", asnData.Format(false));
+        }
 
         [Fact]
         public async Task GetHostEntry_ExampleSub()


### PR DESCRIPTION
First, thank you for your hard work and sharing this library.

You may not have seen CERT records being used in the wild but in the US for example, [CERT resource record](https://datatracker.ietf.org/doc/html/rfc4398) support has been used in the Direct Project since 2011.   See https://www.healthit.gov/faq/what-direct-project for a simplified definition.  

This PR adds the minimum implementation to query for X509 public certificates over DNS.  This will allow the DnsClient.NET library to be used in client code used for the Direct Project.  Specifically, I could take advantage of this feature immediately. 