### PR TITLE
Dropping netstandard1.3, net45 and net5.0 target.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 
 # License header
-#tbd
-#file_header_template = Copyright 2021 Michael Conrad. Licensed under the Apache License, Version 2.0. See LICENSE file for details.
+file_header_template = Copyright 2024 Michael Conrad.\nLicensed under the Apache License, Version 2.0.\nSee LICENSE file for details.
 
 [*.cs]
 #Formatting - new line options

--- a/samples/MiniDig/MiniDig.csproj
+++ b/samples/MiniDig/MiniDig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>MiniDig</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>MiniDig</PackageId>

--- a/samples/MiniDig/MiniDig.csproj
+++ b/samples/MiniDig/MiniDig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MiniDig</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>MiniDig</PackageId>
@@ -24,16 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.1" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/samples/MiniDig/Program.cs
+++ b/samples/MiniDig/Program.cs
@@ -12,12 +12,15 @@ namespace DigApp
             DnsClient.Tracing.Source.Switch.Level = SourceLevels.Warning;
             DnsClient.Tracing.Source.Listeners.Add(new ConsoleTraceListener());
 
-            var app = new CommandLineApplication(throwOnUnexpectedArg: true);
+            var app = new CommandLineApplication();
+            app.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.Throw;
 
             try
             {
-                _ = app.Command("perf", (perfApp) => _ = new PerfCommand(perfApp, args), throwOnUnexpectedArg: true);
-                _ = app.Command("random", (randApp) => _ = new RandomCommand(randApp, args), throwOnUnexpectedArg: true);
+                var perApp = app.Command("perf", (perfApp) => _ = new PerfCommand(perfApp, args));
+                perApp.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.Throw;
+                var randomApp = app.Command("random", (randApp) => _ = new RandomCommand(randApp, args));
+                randomApp.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.Throw;
 
                 // Command must initialize so that it adds the configuration.
                 _ = new DigCommand(app, args);

--- a/samples/MiniDig/Properties/launchSettings.json
+++ b/samples/MiniDig/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "MiniDig": {
       "commandName": "Project",
-      "commandLineArgs": "google.com --cache"
+      "commandLineArgs": "-s localhost mcnet.com txt"
     }
   }
 }

--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
 
-    <TargetFrameworks>net6.0;net5.0;netstandard1.3;netstandard2.0;netstandard2.1;net45;net471</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net472</TargetFrameworks>
     <DebugType>full</DebugType>
 
     <Product>DnsClient.NET</Product>
     <Description>DnsClient.NET is a simple yet very powerful and high performance open source library for the .NET Framework to do DNS lookups</Description>
 
-    <Copyright>Copyright (c) 2021 Michael Conrad</Copyright>
+    <Copyright>Copyright (c) 2024 Michael Conrad</Copyright>
     <Authors>MichaCo</Authors>
     <AssemblyName>DnsClient</AssemblyName>
 
@@ -44,27 +44,14 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
-
 </Project>

--- a/src/DnsClient/DnsDatagramReader.cs
+++ b/src/DnsClient/DnsDatagramReader.cs
@@ -68,37 +68,41 @@ namespace DnsClient
         /// <summary>
         /// As defined in https://tools.ietf.org/html/rfc1035#section-5.1 except '()' or '@' or '.'
         /// </summary>
-        public static string ParseString(ArraySegment<byte> data)
+        public static string ParseString(byte[] data)
         {
-            var result = ParseString(new DnsDatagramReader(data, 0), data.Count);
-            return result;
-        }
-
-        public static string ParseString(DnsDatagramReader reader, int length)
-        {
-            if (reader._count < reader.Index + length)
-            {
-                throw new DnsResponseParseException("Cannot parse string.", reader._data.ToArray(), reader.Index, length);
-            }
-
             var builder = StringBuilderObjectPool.Default.Get();
-            for (var i = 0; i < length; i++)
+
+            //foreach (var b in data)
+            //{
+            //    builder.Append((char)b);
+            //}
+
+            //if ((char)data[0] == '"' && (char)data[data.Length - 1] == '"')
+            //{
+            //    foreach (var b in data)
+            //    {
+            //        builder.Append((char)b);
+            //    }
+            //}
+            //else
+            //{
+            for (var i = 0; i < data.Length; i++)
             {
-                byte b = reader.ReadByte();
+                byte b = data[i];
                 char c = (char)b;
 
                 if (b < 32 || b > 126)
                 {
                     builder.Append("\\" + b.ToString("000", CultureInfo.InvariantCulture));
                 }
-                else if (c == ';')
-                {
-                    builder.Append("\\;");
-                }
-                else if (c == '\\')
-                {
-                    builder.Append("\\\\");
-                }
+                //else if (c == ';')
+                //{
+                //    builder.Append("\\;");
+                //}
+                //else if (c == '\\')
+                //{
+                //    builder.Append("\\\\");
+                //}
                 else if (c == '"')
                 {
                     builder.Append("\\\"");
@@ -108,6 +112,7 @@ namespace DnsClient
                     builder.Append(c);
                 }
             }
+            //}
 
             var value = builder.ToString();
             StringBuilderObjectPool.Default.Return(builder);

--- a/src/DnsClient/DnsDatagramWriter.cs
+++ b/src/DnsClient/DnsDatagramWriter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Text;
 using DnsClient.Internal;

--- a/src/DnsClient/DnsQueryResponse.cs
+++ b/src/DnsClient/DnsQueryResponse.cs
@@ -160,7 +160,7 @@ namespace DnsClient
             {
                 var value = (Header.ToString() + string.Join("", Questions) + string.Join("", AllRecords));
 
-#if NET5_0_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
                 _hashCode = value.GetHashCode(StringComparison.Ordinal);
 #else
                 _hashCode = value.GetHashCode();

--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -234,8 +234,8 @@ namespace DnsClient
             {
                 var length = _reader.ReadByte();
                 var bytes = _reader.ReadBytes(length);
-                var escaped = DnsDatagramReader.ParseString(bytes);
                 var utf = DnsDatagramReader.ReadUTF8String(bytes);
+                var escaped = DnsDatagramReader.ParseString(bytes.ToArray());
                 values.Add(escaped);
                 utf8Values.Add(utf);
             }
@@ -370,7 +370,7 @@ namespace DnsClient
         {
             var flag = _reader.ReadByte();
             var tag = _reader.ReadStringWithLengthPrefix();
-            var stringValue = DnsDatagramReader.ParseString(_reader, info.RawDataLength - 2 - tag.Length);
+            var stringValue = DnsDatagramReader.ParseString(_reader.ReadBytes(info.RawDataLength - 2 - tag.Length).ToArray());
             return new CaaRecord(info, flag, tag, stringValue);
         }
     }

--- a/src/DnsClient/DnsString.cs
+++ b/src/DnsClient/DnsString.cs
@@ -121,7 +121,7 @@ namespace DnsClient
         /// <inheritdoc />
         public override int GetHashCode()
         {
-#if NET5_0_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
             return Value.GetHashCode(StringComparison.Ordinal);
 #else
             return Value.GetHashCode();
@@ -254,7 +254,7 @@ namespace DnsClient
                 data += DotStr;
             }
 
-#if NET5_0_OR_GREATER || NETSTANDARD2_1
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
             if (data.Contains(ACEPrefix, StringComparison.Ordinal))
 #else
             if (data.Contains(ACEPrefix))

--- a/src/DnsClient/DnsTcpMessageHandler.cs
+++ b/src/DnsClient/DnsTcpMessageHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -16,19 +15,53 @@ namespace DnsClient
 
         public override DnsMessageHandleType Type { get; } = DnsMessageHandleType.TCP;
 
-        public override DnsResponseMessage Query(IPEndPoint endpoint, DnsRequestMessage request, TimeSpan timeout)
+        public override DnsResponseMessage Query(IPEndPoint server, DnsRequestMessage request, TimeSpan timeout)
         {
-            if (timeout.TotalMilliseconds != Timeout.Infinite && timeout.TotalMilliseconds < int.MaxValue)
+            CancellationToken cancellationToken = default;
+
+            using var cts = timeout.TotalMilliseconds != Timeout.Infinite && timeout.TotalMilliseconds < int.MaxValue ?
+                new CancellationTokenSource(timeout) : null;
+
+            cancellationToken = cts?.Token ?? default;
+
+            ClientPool pool;
+            while (!_pools.TryGetValue(server, out pool))
             {
-                using (var cts = new CancellationTokenSource(timeout))
-                {
-                    return QueryAsync(endpoint, request, cts.Token)
-                        .WithCancellation(cts.Token)
-                        .ConfigureAwait(false).GetAwaiter().GetResult();
-                }
+                _pools.TryAdd(server, new ClientPool(true, server));
             }
 
-            return QueryAsync(endpoint, request, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var entry = pool.GetNextClient();
+
+            using var cancelCallback = cancellationToken.Register(() =>
+            {
+                if (entry == null)
+                {
+                    return;
+                }
+
+                entry.DisposeClient();
+            });
+
+            try
+            {
+                var response = QueryInternal(entry.Client, request, cancellationToken);
+                ValidateResponse(request, response);
+
+                pool.Enqueue(entry);
+
+                return response;
+            }
+            catch (ObjectDisposedException)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+            catch
+            {
+                entry.DisposeClient();
+                throw;
+            }
         }
 
         public override async Task<DnsResponseMessage> QueryAsync(
@@ -44,7 +77,7 @@ namespace DnsClient
                 _pools.TryAdd(server, new ClientPool(true, server));
             }
 
-            var entry = await pool.GetNextClient().ConfigureAwait(false);
+            var entry = await pool.GetNextClientAsync().ConfigureAwait(false);
 
             using var cancelCallback = cancellationToken.Register(() =>
             {
@@ -60,6 +93,7 @@ namespace DnsClient
             {
                 var response = await QueryAsyncInternal(entry.Client, request, cancellationToken).ConfigureAwait(false);
 
+                cancellationToken.ThrowIfCancellationRequested();
                 ValidateResponse(request, response);
 
                 pool.Enqueue(entry);
@@ -71,6 +105,94 @@ namespace DnsClient
                 entry.DisposeClient();
                 throw;
             }
+        }
+
+        private DnsResponseMessage QueryInternal(TcpClient client, DnsRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var stream = client.GetStream();
+
+            // use a pooled buffer to writer the data + the length of the data later into the first two bytes
+            using (var memory = new PooledBytes(DnsDatagramWriter.BufferSize + 2))
+            using (var writer = new DnsDatagramWriter(new ArraySegment<byte>(memory.Buffer, 2, memory.Buffer.Length - 2)))
+            {
+                GetRequestData(request, writer);
+                int dataLength = writer.Index;
+                memory.Buffer[0] = (byte)((dataLength >> 8) & 0xff);
+                memory.Buffer[1] = (byte)(dataLength & 0xff);
+
+                //await client.Client.SendAsync(new ArraySegment<byte>(memory.Buffer, 0, dataLength + 2), SocketFlags.None).ConfigureAwait(false);
+                stream.Write(memory.Buffer, 0, dataLength + 2);
+                stream.Flush();
+            }
+
+            if (!stream.CanRead)
+            {
+                // might retry
+                throw new TimeoutException();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var responses = new List<DnsResponseMessage>();
+
+            do
+            {
+                int length;
+                using (var lengthBuffer = new PooledBytes(2))
+                {
+                    int bytesReceivedForLen = 0, readForLen;
+                    while ((bytesReceivedForLen += readForLen = stream.Read(lengthBuffer.Buffer, bytesReceivedForLen, 2)) < 2)
+                    {
+                        if (readForLen <= 0)
+                        {
+                            // disconnected, might retry
+                            throw new TimeoutException();
+                        }
+                    }
+
+                    length = lengthBuffer.Buffer[0] << 8 | lengthBuffer.Buffer[1];
+                }
+
+                if (length <= 0)
+                {
+                    // server signals close/disconnecting, might retry
+                    throw new TimeoutException();
+                }
+
+                var buffer = new byte[length];
+                int bytesReceived = 0, read;
+                int readSize = length > 4096 ? 4096 : length;
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                while (!cancellationToken.IsCancellationRequested
+                    && (bytesReceived += read = stream.Read(buffer, bytesReceived, readSize)) < length)
+                {
+
+                    if (read <= 0)
+                    {
+                        // disconnected
+                        throw new TimeoutException();
+                    }
+                    if (bytesReceived + readSize > length)
+                    {
+                        readSize = length - bytesReceived;
+
+                        if (readSize <= 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                DnsResponseMessage response = GetResponseMessage(new ArraySegment<byte>(buffer, 0, bytesReceived));
+                responses.Add(response);
+            } while (stream.DataAvailable && !cancellationToken.IsCancellationRequested);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return DnsResponseMessage.Combine(responses);
         }
 
         private async Task<DnsResponseMessage> QueryAsyncInternal(TcpClient client, DnsRequestMessage request, CancellationToken cancellationToken)
@@ -108,10 +230,10 @@ namespace DnsClient
                 int length;
                 using (var lengthBuffer = new PooledBytes(2))
                 {
-                    int bytesReceived = 0, read;
-                    while ((bytesReceived += (read = await stream.ReadAsync(lengthBuffer.Buffer, bytesReceived, 2, cancellationToken).ConfigureAwait(false))) < 2)
+                    int bytesReceivedForLen = 0, readForLen;
+                    while ((bytesReceivedForLen += (readForLen = await stream.ReadAsync(lengthBuffer.Buffer, bytesReceivedForLen, 2, cancellationToken).ConfigureAwait(false))) < 2)
                     {
-                        if (read <= 0)
+                        if (readForLen <= 0)
                         {
                             // disconnected, might retry
                             throw new TimeoutException();
@@ -127,36 +249,36 @@ namespace DnsClient
                     throw new TimeoutException();
                 }
 
-                using (var memory = new PooledBytes(length))
+                var buffer = new byte[length];
+                int bytesReceived = 0, read;
+                int readSize = length > 4096 ? 4096 : length;
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                while (!cancellationToken.IsCancellationRequested
+                    && (bytesReceived += read = await stream.ReadAsync(buffer, bytesReceived, readSize, cancellationToken).ConfigureAwait(false)) < length)
                 {
-                    int bytesReceived = 0, read;
-                    int readSize = length > 4096 ? 4096 : length;
-
-                    while (!cancellationToken.IsCancellationRequested
-                        && (bytesReceived += read = await stream.ReadAsync(memory.Buffer, bytesReceived, readSize, cancellationToken).ConfigureAwait(false)) < length)
+                    if (read <= 0)
                     {
-                        if (read <= 0)
-                        {
-                            // disconnected
-                            throw new TimeoutException();
-                        }
-                        if (bytesReceived + readSize > length)
-                        {
-                            readSize = length - bytesReceived;
+                        // disconnected
+                        throw new TimeoutException();
+                    }
+                    if (bytesReceived + readSize > length)
+                    {
+                        readSize = length - bytesReceived;
 
-                            if (readSize <= 0)
-                            {
-                                break;
-                            }
+                        if (readSize <= 0)
+                        {
+                            break;
                         }
                     }
-
-                    DnsResponseMessage response = GetResponseMessage(new ArraySegment<byte>(memory.Buffer, 0, bytesReceived));
-
-                    responses.Add(response);
                 }
+
+                DnsResponseMessage response = GetResponseMessage(new ArraySegment<byte>(buffer, 0, bytesReceived));
+                responses.Add(response);
             } while (stream.DataAvailable && !cancellationToken.IsCancellationRequested);
 
+            cancellationToken.ThrowIfCancellationRequested();
             return DnsResponseMessage.Combine(responses);
         }
 
@@ -173,7 +295,32 @@ namespace DnsClient
                 _endpoint = endpoint;
             }
 
-            public async Task<ClientEntry> GetNextClient()
+            public ClientEntry GetNextClient()
+            {
+                if (_disposedValue)
+                {
+                    throw new ObjectDisposedException(nameof(ClientPool));
+                }
+
+                ClientEntry entry = null;
+                if (_enablePool)
+                {
+                    while (entry == null && !TryDequeue(out entry))
+                    {
+                        entry = new ClientEntry(new TcpClient(_endpoint.AddressFamily) { LingerState = new LingerOption(true, 0) }, _endpoint);
+                        entry.Client.Connect(_endpoint.Address, _endpoint.Port);
+                    }
+                }
+                else
+                {
+                    entry = new ClientEntry(new TcpClient(_endpoint.AddressFamily), _endpoint);
+                    entry.Client.Connect(_endpoint.Address, _endpoint.Port);
+                }
+
+                return entry;
+            }
+
+            public async Task<ClientEntry> GetNextClientAsync()
             {
                 if (_disposedValue)
                 {

--- a/src/DnsClient/Interop/Windows/NameResolutionPolicy.cs
+++ b/src/DnsClient/Interop/Windows/NameResolutionPolicy.cs
@@ -22,7 +22,7 @@ namespace DnsClient.Windows
         {
             var nameServers = new HashSet<NameServer>();
 
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
             if (!OperatingSystem.IsWindows())
 #else
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/DnsClient/NameServer.cs
+++ b/src/DnsClient/NameServer.cs
@@ -362,7 +362,7 @@ namespace DnsClient
         {
             List<NameServer> addresses = new List<NameServer>();
 
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
             if (OperatingSystem.IsWindows())
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -379,7 +379,7 @@ namespace DnsClient
                 }
                 catch { }
             }
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
             if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
 #else
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/DnsClient/Protocol/NSecRecord.cs
+++ b/src/DnsClient/Protocol/NSecRecord.cs
@@ -82,7 +82,7 @@ namespace DnsClient.Protocol
         {
             if (data.Length < 2)
             {
-                throw new DnsResponseParseException("Invalid bitmap length, less than 2 bytes available.");
+                yield break;
             }
 
             for (var n = 0; n < data.Length;)

--- a/test-other/ApiDesign/ApiDesign.csproj
+++ b/test-other/ApiDesign/ApiDesign.csproj
@@ -1,17 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <AssemblyName>ApiDesign</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ApiDesign</PackageId>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DnsClient\DnsClient.csproj" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
   </ItemGroup>
 
   <ItemGroup>

--- a/test-other/ApiDesign/Program.cs
+++ b/test-other/ApiDesign/Program.cs
@@ -2,8 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using DnsClient;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace ApiDesign
 {
@@ -11,92 +9,29 @@ namespace ApiDesign
     {
         public static async Task Main()
         {
-            var services = new ServiceCollection();
-            services
-                .AddLogging(c =>
-                {
-                    c.AddConsole();
-                    c.SetMinimumLevel(LogLevel.Debug);
-                })
-                .AddOptions();
+            var i = 0;
 
-            services.AddSingleton(new LookupClientOptions()
+            var client = new LookupClient(new LookupClientOptions()
             {
-                AutoResolveNameServers = true,
                 UseCache = false
             });
 
-            services.AddSingleton<ILookupClient>(f =>
-            {
-                var o = f.GetRequiredService<LookupClientOptions>();
-                return new LookupClient(o);
-            });
-
-            //services.AddSingleton<ILookupClient, LookupClient>();
-
-            /* - -- - - - - - */
-            var provider = services.BuildServiceProvider();
-
-            var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-            DnsClient.Logging.LoggerFactory = new LoggerFactoryWrapper(loggerFactory);
-
-            var logger = provider.GetRequiredService<ILogger<Program>>();
-            var lookup = provider.GetRequiredService<ILookupClient>();
-
-            logger.LogInformation($"Starting stuff...");
-
             while (true)
             {
-                try
+                var response = await client.QueryAsync("google.com", QueryType.A).ConfigureAwait(false);
+                response = client.Query("google.com", QueryType.A);
+                i++;
+
+                if (i % 100 == 0)
                 {
-                    var x = lookup.Query("google.com", QueryType.A);
+                    var mem = GC.GetTotalMemory(true);
+                    Console.WriteLine($"Ran 100x - mem {mem}");
                 }
-                catch { }
 
-                // var r = lookup.QueryServer(new NameServer[] { NameServer.Cloudflare, NameServer.Cloudflare2 }, new DnsQuestion("google.com", QueryType.A));
-
-                await Task.Delay(5000);
-            }
-
-            ////Console.ReadKey();
-        }
-    }
-
-    ////var provider = services.BuildServiceProvider();
-    ////var factory = provider.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
-    ////DnsClient.Logging.LoggerFactory = new LoggerFactoryWrapper(factory);
-
-    internal class LoggerFactoryWrapper : DnsClient.Internal.ILoggerFactory
-    {
-        private readonly ILoggerFactory _microsoftLoggerFactory;
-
-        public LoggerFactoryWrapper(ILoggerFactory microsoftLoggerFactory)
-        {
-            _microsoftLoggerFactory = microsoftLoggerFactory ?? throw new ArgumentNullException(nameof(microsoftLoggerFactory));
-        }
-
-        public DnsClient.Internal.ILogger CreateLogger(string categoryName)
-        {
-            return new DnsLogger(_microsoftLoggerFactory.CreateLogger(categoryName));
-        }
-
-        private class DnsLogger : DnsClient.Internal.ILogger
-        {
-            private readonly ILogger _logger;
-
-            public DnsLogger(ILogger logger)
-            {
-                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            }
-
-            public bool IsEnabled(DnsClient.Internal.LogLevel logLevel)
-            {
-                return _logger.IsEnabled((LogLevel)logLevel);
-            }
-
-            public void Log(DnsClient.Internal.LogLevel logLevel, int eventId, Exception exception, string message, params object[] args)
-            {
-                _logger.Log((LogLevel)logLevel, eventId, exception, message, args);
+                if (i % 1000 == 0)
+                {
+                    Console.WriteLine("ran 1000 times.");
+                }
             }
         }
     }

--- a/test-other/Benchmarks/Benchmarks.csproj
+++ b/test-other/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <AssemblyName>Benchmarks</AssemblyName>

--- a/test-other/Benchmarks/DnsClientBenchmarks.DatagramReader.cs
+++ b/test-other/Benchmarks/DnsClientBenchmarks.DatagramReader.cs
@@ -49,20 +49,6 @@ namespace Benchmarks
                     _ = new IPAddress(_address);
                 }
             }
-
-#if NETCOREAPP2_1
-
-            [Benchmark(OperationsPerInvoke = Ops)]
-            public void FromSpan()
-            {
-                ReadOnlySpan<byte> span = bytes.AsSpan();
-                for (int i = 0; i < Ops; i++)
-                {
-                    _ =  new IPAddress(span);
-                }
-            }
-
-#endif
         }
 
         public class DatagramReader_FullRead

--- a/test-other/Benchmarks/DnsClientBenchmarks.StringSplit.cs
+++ b/test-other/Benchmarks/DnsClientBenchmarks.StringSplit.cs
@@ -31,8 +31,6 @@ namespace Benchmarks
                 return x;
             }
 
-#if NETCOREAPP2_1
-
             [Benchmark]
             public object ManualSplitMemoryT()
             {
@@ -88,8 +86,6 @@ namespace Benchmarks
                 return read;
                 //}
             }
-
-#endif
 
             public static IEnumerable<byte[]> SplitString(string input)
             {

--- a/test-other/DnsClient.PerfTestHost/DnsClient.PerfTestHost.csproj
+++ b/test-other/DnsClient.PerfTestHost/DnsClient.PerfTestHost.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test-other/DnsClient.PerfTestHost/Program.cs
+++ b/test-other/DnsClient.PerfTestHost/Program.cs
@@ -41,7 +41,7 @@ namespace DnsClient.PerfTestHost
                 {
                     RunSync(client, runTime, tasksCount + 8 * i);
 
-                    await RunAsync(client, runTime, tasksCount + 8 * i);
+                    await RunAsync(client, runTime, tasksCount + 8 * i).ConfigureAwait(false);
                 }
             }
 
@@ -98,7 +98,7 @@ namespace DnsClient.PerfTestHost
                 var swatchInner = Stopwatch.StartNew();
                 while (swatch.ElapsedMilliseconds < runTime * 1000)
                 {
-                    var result = await client.QueryAsync("doesntmatter.com", QueryType.A);
+                    var result = await client.QueryAsync("doesntmatter.com", QueryType.A).ConfigureAwait(false);
                     if (result.HasError || result.Answers.Count < 1)
                     {
                         throw new Exception("Expected something");
@@ -117,7 +117,7 @@ namespace DnsClient.PerfTestHost
                 tasks.Add(Worker());
             }
 
-            await Task.WhenAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
 
             double execPerMs = execCount / swatch.ElapsedMilliseconds;
             double exedTimeInMs = 1 / execPerMs;

--- a/test-other/DnsClient.TestsCommon/DnsClient.TestsCommon.csproj
+++ b/test-other/DnsClient.TestsCommon/DnsClient.TestsCommon.csproj
@@ -1,16 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DnsClient\DnsClient.csproj" />

--- a/test-other/OldReference/OldReference.csproj
+++ b/test-other/OldReference/OldReference.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks><!--net45-->;net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net60</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,11 +13,11 @@
     <PackageReference Include="DnsClient" Version="1.1.0" />
   </ItemGroup>-->
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="DnsClient" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net60' ">
     <PackageReference Include="DnsClient" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/test-other/OldReference/TestLookupClient.cs
+++ b/test-other/OldReference/TestLookupClient.cs
@@ -72,32 +72,32 @@ namespace OldReference
         public async Task TestQueryAsync_1_1()
         {
             var client = new LookupClient();
-            await client.QueryAsync("domain", QueryType.A);
-            await client.QueryAsync("domain", QueryType.A, QueryClass.IN);
-            await client.QueryAsync("domain", QueryType.A, cancellationToken: default);
-            await client.QueryAsync("domain", QueryType.A, QueryClass.IN, default);
+            await client.QueryAsync("domain", QueryType.A).ConfigureAwait(false);
+            await client.QueryAsync("domain", QueryType.A, QueryClass.IN).ConfigureAwait(false);
+            await client.QueryAsync("domain", QueryType.A, cancellationToken: default).ConfigureAwait(false);
+            await client.QueryAsync("domain", QueryType.A, QueryClass.IN, default).ConfigureAwait(false);
 
-            await client.QueryReverseAsync(IPAddress.Loopback);
-            await client.QueryReverseAsync(IPAddress.Loopback, default);
+            await client.QueryReverseAsync(IPAddress.Loopback).ConfigureAwait(false);
+            await client.QueryReverseAsync(IPAddress.Loopback, default).ConfigureAwait(false);
 
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A);
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A, cancellationToken: default);
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A, QueryClass.IN);
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A, QueryClass.IN, default);
-            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns.Address }, IPAddress.Loopback);
-            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns.Address }, IPAddress.Loopback, default);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A).ConfigureAwait(false);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A, cancellationToken: default).ConfigureAwait(false);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A, QueryClass.IN).ConfigureAwait(false);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns.Address }, "domain", QueryType.A, QueryClass.IN, default).ConfigureAwait(false);
+            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns.Address }, IPAddress.Loopback).ConfigureAwait(false);
+            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns.Address }, IPAddress.Loopback, default).ConfigureAwait(false);
 
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A);
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A, cancellationToken: default);
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A, QueryClass.IN);
-            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A, QueryClass.IN, default);
-            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns }, IPAddress.Loopback);
-            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns }, IPAddress.Loopback, default);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A).ConfigureAwait(false);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A, cancellationToken: default).ConfigureAwait(false);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A, QueryClass.IN).ConfigureAwait(false);
+            await client.QueryServerAsync(new[] { NameServer.GooglePublicDns }, "domain", QueryType.A, QueryClass.IN, default).ConfigureAwait(false);
+            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns }, IPAddress.Loopback).ConfigureAwait(false);
+            await client.QueryServerReverseAsync(new[] { NameServer.GooglePublicDns }, IPAddress.Loopback, default).ConfigureAwait(false);
 
-            await client.GetHostEntryAsync(IPAddress.Loopback);
-            await client.GetHostEntryAsync("localhost");
-            await client.GetHostNameAsync(IPAddress.Loopback);
-            await client.ResolveServiceAsync("domain", "srv", tag: null);
+            await client.GetHostEntryAsync(IPAddress.Loopback).ConfigureAwait(false);
+            await client.GetHostEntryAsync("localhost").ConfigureAwait(false);
+            await client.GetHostNameAsync(IPAddress.Loopback).ConfigureAwait(false);
+            await client.ResolveServiceAsync("domain", "srv", tag: null).ConfigureAwait(false);
         }
 
         public void TestProtocol_1_1()
@@ -168,7 +168,7 @@ namespace OldReference
             _ = wks.Address.ToString() + wks.Protocol + wks.Bitmap.ToString();
         }
 
-#if NETCOREAPP3_1
+#if NET6_0
 
         public void TestProtocol_1_2()
         {
@@ -183,14 +183,5 @@ namespace OldReference
         }
 
 #endif
-        ////public void TestProtocol_1_3()
-        ////{
-        ////    var dnsKey = new DnsKeyRecord();
-        ////    var ds = new DsRecord();
-        ////    var nsec = new NsecRecord();
-        ////    var rrsig = new RRSigRecord();
-        ////    new TlsaRecord();
-        ////    new UnknownRecord();
-        ////}
     }
 }

--- a/test/DnsClient.Tests/ApiCompatibilityTest.cs
+++ b/test/DnsClient.Tests/ApiCompatibilityTest.cs
@@ -70,7 +70,7 @@ namespace DnsClient.Tests
             test.TestProtocol_1_1();
         }
 
-#if NETCOREAPP3_1
+#if NET6_0
         [Fact]
         public void API_CompatProtocol_1_2()
         {

--- a/test/DnsClient.Tests/DnsClient.Tests.csproj
+++ b/test/DnsClient.Tests/DnsClient.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>
-      net471;netcoreapp3.1;net6.0;
+      net472;
+      net6.0;
     </TargetFrameworks>
     <AssemblyName>DnsClient.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>

--- a/test/DnsClient.Tests/DnsRecordFactoryTest.cs
+++ b/test/DnsClient.Tests/DnsRecordFactoryTest.cs
@@ -351,6 +351,23 @@ namespace DnsClient.Tests
         }
 
         [Fact]
+        public void DnsRecordFactory_TXTRecord_DoNotEscape()
+        {
+            var text = "v=DKIM1; k=rsa;";
+            var line = Encoding.ASCII.GetBytes(text);
+            var data = new List<byte>();
+            data.Add((byte)line.Length);
+            data.AddRange(line);
+
+            var factory = GetFactory(data.ToArray());
+            var info = new ResourceRecordInfo("query.example.com", ResourceRecordType.TXT, QueryClass.IN, 0, data.Count);
+
+            var result = factory.GetRecord(info) as TxtRecord;
+
+            Assert.Equal(result.EscapedText.ElementAt(0), text);
+        }
+
+        [Fact]
         public void DnsRecordFactory_TLSARecord()
         {
             var certificateUsage = 0;
@@ -473,7 +490,7 @@ namespace DnsClient.Tests
 
             Assert.Equal(2, result.EscapedText.Count);
             Assert.Equal(result.Text.ElementAt(0), textA);
-            Assert.Equal("\\\"\\195\\164\\195\\182\\195\\188 \\\\slash/! @bla.com \\\"", result.EscapedText.ElementAt(0));
+            Assert.Equal("\\\"\\195\\164\\195\\182\\195\\188 \\slash/! @bla.com \\\"", result.EscapedText.ElementAt(0));
             Assert.Equal(result.Text.ElementAt(1), textB);
             Assert.Equal(result.EscapedText.ElementAt(1), textB);
         }

--- a/test/DnsClient.Tests/DnsStringTest.cs
+++ b/test/DnsClient.Tests/DnsStringTest.cs
@@ -55,7 +55,7 @@ namespace DnsClient.Tests
             Assert.Equal(3, name.NumberOfLabels);
         }
 
-#if !NET5_0_OR_GREATER // Actually changed behavior in NET50
+#if !NET6_0_OR_GREATER // Actually changed behavior in NET50
         [Fact]
         public void DnsString_ReadPuny_IDNA2003_Invalid()
         {

--- a/test/DnsClient.Tests/MockExampleTest.cs
+++ b/test/DnsClient.Tests/MockExampleTest.cs
@@ -1,5 +1,4 @@
-﻿#if !NETCOREAPP1_1
-using System;
+﻿using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -44,4 +43,3 @@ namespace DnsClient.Tests
         }
     }
 }
-#endif

--- a/test/DnsClient.ThirdParty.Tests/DnsClient.ThirdParty.Tests.csproj
+++ b/test/DnsClient.ThirdParty.Tests/DnsClient.ThirdParty.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net471;netcoreapp3.1;net6.0
+      net472;net6.0
     </TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -26,12 +26,8 @@
     <ProjectReference Include="..\..\src\DnsClient\DnsClient.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="MongoDB.Driver" Version="2.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/test/DnsClient.ThirdParty.Tests/ThrirdPartyTest.cs
+++ b/test/DnsClient.ThirdParty.Tests/ThrirdPartyTest.cs
@@ -11,7 +11,7 @@ namespace DnsClient.ThirdParty.Tests
     {
         private const string TestConnection = "mongodb+srv://doesnotexist.internal.example/?serverSelectionTimeout=2&connectTimeoutMS=2000";
 
-#if NET471
+#if NET472
 
         [Fact]
         public void MongoDriver_Compat_2_8()
@@ -22,7 +22,7 @@ namespace DnsClient.ThirdParty.Tests
 
 #endif
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         [Fact]
         public void MongoDriver_Compat_210()
         {

--- a/tools/etc/zones/db.192.168.178.txt
+++ b/tools/etc/zones/db.192.168.178.txt
@@ -34,6 +34,7 @@ srv3			IN		A  		192.168.178.26
 srv4			IN		A  		192.168.178.27
 uber			IN		A		192.168.178.30
 @				IN		TXT		"some long text with some stuff in it {lala:blub}"
+@				IN 		TXT 	"v=DKIM1; k=rsa;"
 @				IN		TXT		(some text "separated by" space
 										with new line stuff too)
 @				IN		TXT		more "(text with)" "\"special\" öäÜ!""§$%\\/" @stuff \;and ";fake comment"


### PR DESCRIPTION
* Dropping netstandard1.3, net45 and net5.0 target.
* Removing unnecessary dependencies.
* Adding a synchronous impl for TCP.
* Removing UDP read buffer implementation because of memory issues in Full NET framework (must be a bug, didn't find a workaround) - fixes #192 
* Slight adjustment to string value parsing fixes #195 
* Allowing empty bitmap on NSec records fixes #193 