### PR TITLE
Reduce allocations

### DIFF
--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -46,10 +46,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/src/DnsClient/DnsClient.csproj
+++ b/src/DnsClient/DnsClient.csproj
@@ -46,12 +46,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/src/DnsClient/DnsTcpMessageHandler.cs
+++ b/src/DnsClient/DnsTcpMessageHandler.cs
@@ -114,7 +114,8 @@ namespace DnsClient
             var stream = client.GetStream();
 
             // use a pooled buffer to writer the data + the length of the data later into the first two bytes
-            using (var memory = new PooledBytes(DnsDatagramWriter.BufferSize + 2))
+            using var memory = new PooledBytes(DnsQueryOptions.MaximumBufferSize);
+
             using (var writer = new DnsDatagramWriter(new ArraySegment<byte>(memory.Buffer, 2, memory.Buffer.Length - 2)))
             {
                 GetRequestData(request, writer);
@@ -136,24 +137,21 @@ namespace DnsClient
             cancellationToken.ThrowIfCancellationRequested();
 
             var responses = new List<DnsResponseMessage>();
+            Span<byte> buf = memory.Buffer.AsSpan();
 
             do
             {
-                int length;
-                using (var lengthBuffer = new PooledBytes(2))
+                int bytesReceivedForLen = 0, readForLen;
+                while ((bytesReceivedForLen += readForLen = stream.Read(buf.Slice(bytesReceivedForLen, 2))) < 2)
                 {
-                    int bytesReceivedForLen = 0, readForLen;
-                    while ((bytesReceivedForLen += readForLen = stream.Read(lengthBuffer.Buffer, bytesReceivedForLen, 2)) < 2)
+                    if (readForLen <= 0)
                     {
-                        if (readForLen <= 0)
-                        {
-                            // disconnected, might retry
-                            throw new TimeoutException();
-                        }
+                        // disconnected, might retry
+                        throw new TimeoutException();
                     }
-
-                    length = lengthBuffer.Buffer[0] << 8 | lengthBuffer.Buffer[1];
                 }
+
+                int length = buf[0] << 8 | buf[1];
 
                 if (length <= 0)
                 {
@@ -161,7 +159,7 @@ namespace DnsClient
                     throw new TimeoutException();
                 }
 
-                var buffer = new byte[length];
+                var buffer = length <= memory.Buffer.Length ? memory.Buffer : new byte[length];
                 int bytesReceived = 0, read;
                 int readSize = length > 4096 ? 4096 : length;
 
@@ -202,7 +200,8 @@ namespace DnsClient
             var stream = client.GetStream();
 
             // use a pooled buffer to writer the data + the length of the data later into the first two bytes
-            using (var memory = new PooledBytes(DnsDatagramWriter.BufferSize + 2))
+            using var memory = new PooledBytes(DnsQueryOptions.MaximumBufferSize);
+
             using (var writer = new DnsDatagramWriter(new ArraySegment<byte>(memory.Buffer, 2, memory.Buffer.Length - 2)))
             {
                 GetRequestData(request, writer);
@@ -210,7 +209,6 @@ namespace DnsClient
                 memory.Buffer[0] = (byte)((dataLength >> 8) & 0xff);
                 memory.Buffer[1] = (byte)(dataLength & 0xff);
 
-                //await client.Client.SendAsync(new ArraySegment<byte>(memory.Buffer, 0, dataLength + 2), SocketFlags.None).ConfigureAwait(false);
                 await stream.WriteAsync(memory.Buffer, 0, dataLength + 2, cancellationToken).ConfigureAwait(false);
                 await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -228,20 +226,18 @@ namespace DnsClient
             do
             {
                 int length;
-                using (var lengthBuffer = new PooledBytes(2))
+                int bytesReceivedForLen = 0, readForLen;
+                while ((bytesReceivedForLen += (readForLen = await stream.ReadAsync(memory.Buffer, bytesReceivedForLen, 2, cancellationToken).ConfigureAwait(false))) < 2)
                 {
-                    int bytesReceivedForLen = 0, readForLen;
-                    while ((bytesReceivedForLen += (readForLen = await stream.ReadAsync(lengthBuffer.Buffer, bytesReceivedForLen, 2, cancellationToken).ConfigureAwait(false))) < 2)
+                    if (readForLen <= 0)
                     {
-                        if (readForLen <= 0)
-                        {
-                            // disconnected, might retry
-                            throw new TimeoutException();
-                        }
+                        // disconnected, might retry
+                        throw new TimeoutException();
                     }
-
-                    length = lengthBuffer.Buffer[0] << 8 | lengthBuffer.Buffer[1];
                 }
+
+                length = memory.Buffer[0] << 8 | memory.Buffer[1];
+
 
                 if (length <= 0)
                 {
@@ -249,7 +245,7 @@ namespace DnsClient
                     throw new TimeoutException();
                 }
 
-                var buffer = new byte[length];
+                byte[] buffer = memory.Buffer.Length <= length ? memory.Buffer : new byte[length];
                 int bytesReceived = 0, read;
                 int readSize = length > 4096 ? 4096 : length;
 

--- a/src/DnsClient/DnsUdpMessageHandler.cs
+++ b/src/DnsClient/DnsUdpMessageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
@@ -10,7 +11,7 @@ namespace DnsClient
 {
     internal class DnsUdpMessageHandler : DnsMessageHandler
     {
-        private const int MaxSize = 4096;
+        private const int MaxSize = DnsQueryOptions.MaximumBufferSize;
 
         public override DnsMessageHandleType Type { get; } = DnsMessageHandleType.UDP;
 
@@ -23,31 +24,34 @@ namespace DnsClient
             DnsRequestMessage request,
             TimeSpan timeout)
         {
-            var udpClient = new UdpClient(endpoint.AddressFamily);
+            Socket socket = new Socket(endpoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(MaxSize);
 
             try
             {
                 // -1 indicates infinite
                 int timeoutInMillis = timeout.TotalMilliseconds >= int.MaxValue ? -1 : (int)timeout.TotalMilliseconds;
-                udpClient.Client.ReceiveTimeout = timeoutInMillis;
-                udpClient.Client.SendTimeout = timeoutInMillis;
+                socket.ReceiveTimeout = timeoutInMillis;
+                socket.SendTimeout = timeoutInMillis;
 
-                using (var writer = new DnsDatagramWriter())
+                using (var writer = new DnsDatagramWriter(new ArraySegment<byte>(buffer)))
                 {
                     GetRequestData(request, writer);
-                    udpClient.Send(writer.Data.Array, writer.Data.Count, endpoint);
+                    socket.SendTo(writer.Data.Array, writer.Data.Count, SocketFlags.None, endpoint);
                 }
 
-                var result = udpClient.Receive(ref endpoint);
-                var response = GetResponseMessage(new ArraySegment<byte>(result, 0, result.Length));
+                EndPoint ep = endpoint;
+                int count = socket.ReceiveFrom(buffer, SocketFlags.None, ref ep);
+                var response = GetResponseMessage(new ArraySegment<byte>(buffer, 0, count));
                 ValidateResponse(request, response);
                 return response;
             }
             finally
             {
+                ArrayPool<byte>.Shared.Return(buffer);
                 try
                 {
-                    udpClient.Dispose();
+                    socket.Dispose();
                 }
                 catch { }
             }
@@ -60,25 +64,23 @@ namespace DnsClient
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var udpClient = new UdpClient(endpoint.AddressFamily);
-
+            Socket socket = new Socket(endpoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(MaxSize);
             try
             {
                 using var callback = cancellationToken.Register(() =>
                 {
-                    udpClient.Dispose();
+                    socket.Dispose();
                 });
 
                 using (var writer = new DnsDatagramWriter())
                 {
                     GetRequestData(request, writer);
-                    await udpClient.SendAsync(writer.Data.Array, writer.Data.Count, endpoint).ConfigureAwait(false);
+                    await socket.SendToAsync(writer.Data, endpoint).ConfigureAwait(false);
                 }
 
-                var readSize = udpClient.Available > MaxSize ? udpClient.Available : MaxSize;
-
-                var result = await udpClient.ReceiveAsync().ConfigureAwait(false);
-                var response = GetResponseMessage(new ArraySegment<byte>(result.Buffer, 0, result.Buffer.Length));
+                var result = await socket.ReceiveFromAsync(new ArraySegment<byte>(buffer), endpoint).ConfigureAwait(false);
+                var response = GetResponseMessage(new ArraySegment<byte>(buffer, 0, result.ReceivedBytes));
                 ValidateResponse(request, response);
                 return response;
             }
@@ -93,9 +95,10 @@ namespace DnsClient
             }
             finally
             {
+                ArrayPool<byte>.Shared.Return(buffer);
                 try
                 {
-                    udpClient.Dispose();
+                    socket.Dispose();
                 }
                 catch { }
             }

--- a/src/DnsClient/Internal/Polyfill.cs
+++ b/src/DnsClient/Internal/Polyfill.cs
@@ -1,0 +1,126 @@
+﻿// Copyright 2024 Michael Conrad.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file for details.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace DnsClient.Internal
+{
+    internal static class Polyfill
+    {
+        public static Task<SocketReceiveFromResult> ReceiveFromAsync(this Socket socket, ArraySegment<byte> buffer, EndPoint endPoint)
+#if NETFRAMEWORK || NETSTANDARD2_0
+            => ReceiveFromAsyncAPM(socket, buffer, endPoint);      
+#else
+            => socket.ReceiveFromAsync(buffer, SocketFlags.None, endPoint);
+#endif
+
+        public static Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, EndPoint endPoint)
+#if NETFRAMEWORK || NETSTANDARD2_0
+            => SendToAsyncAPM(socket, buffer, endPoint);      
+#else
+            => socket.SendToAsync(buffer, SocketFlags.None, endPoint);
+#endif
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // Task-based async Socket methods result in memory leak on .NET Framework:
+        // https://github.com/MichaCo/DnsClient.NET/issues/192
+        // To avoid this, we use the old Begin/End pattern.
+        public static Task<SocketReceiveFromResult> ReceiveFromAsyncAPM(Socket socket, ArraySegment<byte> buffer, EndPoint ep)
+        {
+            object[] packedArguments = new object[] { socket, ep };
+
+            return Task<SocketReceiveFromResult>.Factory.FromAsync(
+                (buffer, callback, state) =>
+                {
+                    var arguments = (object[])state;
+                    var s = (Socket)arguments[0];
+                    var e = (EndPoint)arguments[1];
+
+                    IAsyncResult result = s.BeginReceiveFrom(
+                        buffer.Array,
+                        buffer.Offset,
+                        buffer.Count,
+                        SocketFlags.None,
+                        ref e,
+                        callback,
+                        state);
+
+                    arguments[1] = e;
+                    return result;
+                },
+                asyncResult =>
+                {
+                    var arguments = (object[])asyncResult.AsyncState;
+                    var s = (Socket)arguments[0];
+                    var e = (EndPoint)arguments[1];
+
+                    int bytesReceived = s.EndReceiveFrom(asyncResult, ref e);
+
+                    return new SocketReceiveFromResult()
+                    {
+                        ReceivedBytes = bytesReceived,
+                        RemoteEndPoint = e
+                    };
+                },
+                buffer,
+                state: packedArguments);
+        }
+
+        public static Task<int> SendToAsyncAPM(this Socket socket, ArraySegment<byte> buffer, EndPoint ep)
+        {
+            return Task<int>.Factory.FromAsync(
+                (targetBuffer, flags, endPoint, callback, state) => ((Socket)state).BeginSendTo(
+                                                                        targetBuffer.Array,
+                                                                        targetBuffer.Offset,
+                                                                        targetBuffer.Count,
+                                                                        flags,
+                                                                        endPoint,
+                                                                        callback,
+                                                                        state),
+                asyncResult => ((Socket)asyncResult.AsyncState).EndSendTo(asyncResult),
+                buffer,
+                SocketFlags.None,
+                ep,
+                state: socket);
+        }
+
+        // Polyfill missing ReadAsync overload for .NET Framework.
+        public static async Task<int> ReadAsync(this Stream stream, Memory<byte> buffer)
+        {
+            byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                int read = await stream.ReadAsync(array, 0, buffer.Length);
+                array.AsMemory(0, read).CopyTo(buffer);
+                return read;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(array);
+            }
+        }
+
+        // Polyfill missing Read overload for .NET Framework.
+        public static int Read(this Stream stream, Span<byte> buffer)
+        {
+            byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                int read = stream.Read(array, 0, buffer.Length);
+                array.AsSpan(0, read).CopyTo(buffer);
+                return read;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(array);
+            }
+        }
+#endif
+    }
+}

--- a/src/DnsClient/Internal/Polyfill.cs
+++ b/src/DnsClient/Internal/Polyfill.cs
@@ -89,22 +89,6 @@ namespace DnsClient.Internal
                 ep,
                 state: socket);
         }
-
-        // Polyfill missing Span-based Read on .NET Framework.
-        public static int Read(this Stream stream, Span<byte> buffer)
-        {
-            byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
-            try
-            {
-                int read = stream.Read(array, 0, buffer.Length);
-                array.AsSpan(0, read).CopyTo(buffer);
-                return read;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(array);
-            }
-        }
 #endif
     }
 }

--- a/src/DnsClient/Internal/Polyfill.cs
+++ b/src/DnsClient/Internal/Polyfill.cs
@@ -90,23 +90,7 @@ namespace DnsClient.Internal
                 state: socket);
         }
 
-        // Polyfill missing ReadAsync overload for .NET Framework.
-        public static async Task<int> ReadAsync(this Stream stream, Memory<byte> buffer)
-        {
-            byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
-            try
-            {
-                int read = await stream.ReadAsync(array, 0, buffer.Length);
-                array.AsMemory(0, read).CopyTo(buffer);
-                return read;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(array);
-            }
-        }
-
-        // Polyfill missing Read overload for .NET Framework.
+        // Polyfill missing Span-based Read on .NET Framework.
         public static int Read(this Stream stream, Span<byte> buffer)
         {
             byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);


### PR DESCRIPTION
Fixes #213 by implementing both strategies suggested there.

The .NET Framework memory leak is worked around by [adapting](https://github.com/dotnet/corefx/blob/release/1.1.0/src/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs) APM -> Task wrappers for async socket operations when targeting net472or netstandard2.0. (`UdpClient`s implementation is doing the same.)