### PR TITLE
Thread safe ID generation

### DIFF
--- a/src/DnsClient/DnsRequestHeader.cs
+++ b/src/DnsClient/DnsRequestHeader.cs
@@ -114,8 +114,13 @@ namespace DnsClient
 #else
             lock (s_random)
             {
-                s_random.GetBytes(s_randomBytes);
-                return (ushort)(s_randomBytes[0] << 8 | s_randomBytes[1]);
+                ushort result;
+                do
+                {
+                    s_random.GetBytes(s_randomBytes);
+                    result = (ushort)(s_randomBytes[0] << 8 | s_randomBytes[1]);    
+                } while (result == 0);
+                return result;
             }
 #endif
         }

--- a/test/DnsClient.Tests/DnsRequestHeaderTest.cs
+++ b/test/DnsClient.Tests/DnsRequestHeaderTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClient.Tests
@@ -48,6 +50,20 @@ namespace DnsClient.Tests
             Assert.Equal(8448, header.RawFlags);
 
             Assert.Equal(DnsOpCode.Notify, header.OpCode);
+        }
+
+        [Fact]
+        public void DnsRequestHeader_IdIsPseudoUnique()
+        {
+            ConcurrentDictionary<int, int> ids = new ConcurrentDictionary<int, int>();
+
+            Parallel.For(0, 1000, i =>
+            {
+                var header = new DnsRequestHeader(DnsOpCode.Query);
+                ids.TryAdd(header.Id, 0);
+            });
+
+            Assert.True(ids.Count > 900);
         }
     }
 }

--- a/test/DnsClient.Tests/DnsRequestHeaderTest.cs
+++ b/test/DnsClient.Tests/DnsRequestHeaderTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -60,6 +62,7 @@ namespace DnsClient.Tests
             Parallel.For(0, 1000, i =>
             {
                 var header = new DnsRequestHeader(DnsOpCode.Query);
+                Assert.NotEqual(0, header.Id);
                 ids.TryAdd(header.Id, 0);
             });
 

--- a/test/DnsClient.Tests/DnsRequestHeaderTest.cs
+++ b/test/DnsClient.Tests/DnsRequestHeaderTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
+﻿using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/test/DnsClient.Tests/DnsRequestHeaderTest.cs
+++ b/test/DnsClient.Tests/DnsRequestHeaderTest.cs
@@ -63,7 +63,7 @@ namespace DnsClient.Tests
                 ids.TryAdd(header.Id, 0);
             });
 
-            Assert.True(ids.Count > 900);
+            Assert.True(ids.Count > 950, $"Only {ids.Count} of 1000 ids are unique!");
         }
     }
 }


### PR DESCRIPTION
Fix #209 ~and use cryptographically strong random numbers~ *Edit: removed the latter, the vulnerability doesn't apply to clients.*.