### PR TITLE
Added support for CDS/CDNS records as specified in RFC 7344

### DIFF
--- a/src/DnsClient/DnsRecordFactory.cs
+++ b/src/DnsClient/DnsRecordFactory.cs
@@ -180,6 +180,14 @@ namespace DnsClient
                     result = ResolveTlsaRecord(info);
                     break;
 
+                case ResourceRecordType.CDS: //59
+                    result = ResolveCdsRecord(info);
+                    break;
+
+                case ResourceRecordType.CDNS: //60
+                    result = ResolveCdnsKeyRecord(info);
+                    break;
+
                 case ResourceRecordType.SPF: // 99
                     result = ResolveTxtRecord(info);
                     break;
@@ -376,6 +384,26 @@ namespace DnsClient
             var matchingType = _reader.ReadByte();
             var certificateAssociationData = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
             return new TlsaRecord(info, certificateUsage, selector, matchingType, certificateAssociationData);
+        }
+
+        private CdsRecord ResolveCdsRecord(ResourceRecordInfo info)
+        {
+            var startIndex = _reader.Index;
+            var keyTag = _reader.ReadUInt16NetworkOrder();
+            var algorithm = _reader.ReadByte();
+            var digestType = _reader.ReadByte();
+            var digest = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
+            return new CdsRecord(info, keyTag, algorithm, digestType, digest);
+        }
+
+        private CdnsKeyRecord ResolveCdnsKeyRecord(ResourceRecordInfo info)
+        {
+            var startIndex = _reader.Index;
+            int flags = _reader.ReadUInt16NetworkOrder();
+            var protocol = _reader.ReadByte();
+            var algorithm = _reader.ReadByte();
+            var publicKey = _reader.ReadBytesToEnd(startIndex, info.RawDataLength).ToArray();
+            return new CdnsKeyRecord(info, flags, protocol, algorithm, publicKey);
         }
 
         private UriRecord ResolveUriRecord(ResourceRecordInfo info)

--- a/src/DnsClient/Protocol/CdnsKeyRecord.cs
+++ b/src/DnsClient/Protocol/CdnsKeyRecord.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace DnsClient.Protocol
+{
+    /// <summary>
+    /// https://datatracker.ietf.org/doc/html/rfc7344#section-3.2
+    /// The wire and presentation format of the CDNSKEY ("Child DNSKEY") resource record is identical to the DNSKEY record.
+    /// </summary>
+    public class CdnsKeyRecord : DnsKeyRecord
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CdnsKeyRecord"/> class. The record is identical to <see cref="DnsKeyRecord"/>
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="flags"></param>
+        /// <param name="protocol"></param>
+        /// <param name="algorithm"></param>
+        /// <param name="publicKey"></param>
+        /// <exception cref="ArgumentNullException">If <paramref name="info"/> or <paramref name="publicKey"/> is null.</exception>
+        public CdnsKeyRecord(ResourceRecordInfo info, int flags, byte protocol, byte algorithm, byte[] publicKey) : base(info, flags, protocol, algorithm, publicKey)
+        {
+        }
+    }
+}

--- a/src/DnsClient/Protocol/CdsRecord.cs
+++ b/src/DnsClient/Protocol/CdsRecord.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace DnsClient.Protocol
+{
+    /// <summary>
+    /// https://datatracker.ietf.org/doc/html/rfc7344#section-3.1
+    /// The wire and presentation format of the Child DS (CDS) resource record is identical to the DS record [RFC4034]
+    /// </summary>
+    public class CdsRecord : DsRecord
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CdsRecord"/> class. The record is identical to <see cref="DsRecord"/>
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="keyTag"></param>
+        /// <param name="algorithm"></param>
+        /// <param name="digestType"></param>
+        /// <param name="digest"></param>
+        /// <exception cref="ArgumentNullException">If <paramref name="info"/> or <paramref name="digest"/> is null.</exception>
+        public CdsRecord(ResourceRecordInfo info, int keyTag, byte algorithm, byte digestType, byte[] digest) : base(info, keyTag, algorithm, digestType, digest)
+        {
+        }
+    }
+}

--- a/src/DnsClient/Protocol/ResourceRecordType.cs
+++ b/src/DnsClient/Protocol/ResourceRecordType.cs
@@ -242,6 +242,20 @@ namespace DnsClient.Protocol
         TLSA = 52,
 
         /// <summary>
+        /// TLSA rfc7344.
+        /// </summary>
+        /// <seealso href="https://https://tools.ietf.org/html/rfc7344">RFC 7344</seealso>
+        CDS = 59,
+
+        /// <summary>
+        /// TLSA rfc7344.
+        /// </summary>
+        /// <seealso href="https://https://tools.ietf.org/html/rfc7344">RFC 7344</seealso>
+        CDNS = 60,
+
+
+
+        /// <summary>
         /// SPF records don't officially have a dedicated RR type, <see cref="TXT"/> should be used instead.
         /// The behavior of TXT and SPF are the same.
         /// </summary>

--- a/src/DnsClient/QueryType.cs
+++ b/src/DnsClient/QueryType.cs
@@ -226,6 +226,19 @@ namespace DnsClient
         TLSA = ResourceRecordType.TLSA,
 
         /// <summary>
+        /// TLSA rfc7344.
+        /// </summary>
+        /// <seealso href="https://https://tools.ietf.org/html/rfc7344">RFC 7344</seealso>
+        CDS = ResourceRecordType.CDS,
+
+        /// <summary>
+        /// TLSA rfc7344.
+        /// </summary>
+        /// <seealso href="https://https://tools.ietf.org/html/rfc7344">RFC 7344</seealso>
+        CDNS = ResourceRecordType.CDNS,
+
+
+        /// <summary>
         /// SPF records don't officially have a dedicated RR type, <see cref="ResourceRecordType.TXT"/> should be used instead.
         /// The behavior of TXT and SPF are the same.
         /// </summary>

--- a/test/DnsClient.Tests/DnsResponseParsingTest.cs
+++ b/test/DnsClient.Tests/DnsResponseParsingTest.cs
@@ -51,7 +51,9 @@ namespace DnsClient.Tests
                 ResourceRecordType.SPF,
                 ResourceRecordType.DNSKEY,
                 ResourceRecordType.DS,
-                ResourceRecordType.CERT
+                ResourceRecordType.CERT,
+                ResourceRecordType.CDS,
+                ResourceRecordType.CDNS
             };
 
             foreach (var t in types)


### PR DESCRIPTION
In our organization we need support for CDS and CDNS records in DnsClient.NET. I have implemented support for these records.